### PR TITLE
fix: canvas SVG bounds for bezier edges

### DIFF
--- a/test/canvas-renderer.test.ts
+++ b/test/canvas-renderer.test.ts
@@ -334,6 +334,26 @@ describe('JsonCanvasRenderer', () => {
       assert.ok(svg.includes('height="240"'), 'Should have correct height');
     });
 
+    it('should include bezier control points in bounds to avoid clipping', () => {
+      // A right->right long edge has control points extending beyond node bounds.
+      // If bounds are computed from nodes only, the curve gets clipped on the right side.
+      const svg = generateSvg({
+        nodes: [
+          { id: 'kickoff', type: 'text', text: 'Start', x: 0, y: 0, width: 100, height: 60 },
+          { id: 'operate', type: 'text', text: 'End', x: 390, y: 630, width: 100, height: 60 }
+        ],
+        edges: [
+          { id: 'e1', fromNode: 'operate', fromSide: 'right', toNode: 'kickoff', toSide: 'right' }
+        ]
+      });
+
+      const match = svg.match(/width="(\d+)"/);
+      assert.ok(match, 'Should have width attribute');
+      const width = parseInt(match![1], 10);
+      // Node-only width would be 490 + padding*2 = 570. The curve should increase bounds beyond that.
+      assert.ok(width > 620, `Expected SVG width to include curve (avoid clipping), got width=${width}`);
+    });
+
     it('should handle negative coordinates', () => {
       const svg = generateSvg({
         nodes: [


### PR DESCRIPTION
`canvas-renderer` 生成 SVG 时 `viewBox` 的边界只按节点（nodes）计算，没把边（edges）的贝塞尔曲线范围算进去，导致长曲线（尤其 right->right 这种控制点向右外扩）超出 viewBox 被裁剪。

Co-authored-by: codex

<img width="821" height="865" alt="ScreenShot_2026-01-21_035601_479" src="https://github.com/user-attachments/assets/1acb970e-4b8a-44be-92b9-ae23bbdd635a" />
