### PR TITLE
fix(obsidian): support svg wikilink embeds

### DIFF
--- a/obsidian/src/host/obsidian-svg-embed-rewrite.ts
+++ b/obsidian/src/host/obsidian-svg-embed-rewrite.ts
@@ -1,0 +1,199 @@
+/**
+ * Rewrites Obsidian SVG embeds into standard Markdown image syntax.
+ *
+ * The shared markdown pipeline does not understand ![[...]] embeds, but it
+ * already supports normal image nodes pointing to SVG files.
+ */
+
+type LinkResolver = (linkPath: string) => string | null;
+
+export function rewriteObsidianSvgEmbeds(
+  markdown: string,
+  sourcePath: string,
+  resolveLinkPath: LinkResolver,
+): string {
+  if (!markdown.includes('![[')) {
+    return markdown;
+  }
+
+  const newline = markdown.includes('\r\n') ? '\r\n' : '\n';
+  const hasTrailingNewline = markdown.endsWith('\n');
+  const lines = markdown.split(/\r?\n/);
+  let activeFence: { char: '`' | '~'; length: number } | null = null;
+
+  const rewritten = lines.map((line) => {
+    const fence = parseFenceMarker(line);
+    if (fence) {
+      if (!activeFence) {
+        activeFence = fence;
+      } else if (activeFence.char === fence.char && fence.length >= activeFence.length) {
+        activeFence = null;
+      }
+      return line;
+    }
+
+    if (activeFence) {
+      return line;
+    }
+
+    return rewriteInlineSvgEmbeds(line, sourcePath, resolveLinkPath);
+  }).join(newline);
+
+  return hasTrailingNewline && !rewritten.endsWith(newline)
+    ? rewritten + newline
+    : rewritten;
+}
+
+function parseFenceMarker(line: string): { char: '`' | '~'; length: number } | null {
+  const match = line.match(/^(?: {0,3})(`{3,}|~{3,})/);
+  if (!match) {
+    return null;
+  }
+
+  const marker = match[1];
+  const char = marker[0];
+  if (char !== '`' && char !== '~') {
+    return null;
+  }
+
+  return { char, length: marker.length };
+}
+
+function rewriteInlineSvgEmbeds(
+  line: string,
+  sourcePath: string,
+  resolveLinkPath: LinkResolver,
+): string {
+  let output = '';
+  let index = 0;
+
+  while (index < line.length) {
+    if (line[index] === '`') {
+      const tickCount = countRun(line, index, '`');
+      const closingIndex = line.indexOf('`'.repeat(tickCount), index + tickCount);
+      if (closingIndex === -1) {
+        output += line.slice(index);
+        break;
+      }
+
+      output += line.slice(index, closingIndex + tickCount);
+      index = closingIndex + tickCount;
+      continue;
+    }
+
+    if (line.startsWith('![[', index)) {
+      const closingIndex = line.indexOf(']]', index + 3);
+      if (closingIndex !== -1) {
+        const rewritten = rewriteSingleSvgEmbed(
+          line.slice(index + 3, closingIndex),
+          sourcePath,
+          resolveLinkPath,
+        );
+        if (rewritten) {
+          output += rewritten;
+          index = closingIndex + 2;
+          continue;
+        }
+      }
+    }
+
+    output += line[index];
+    index += 1;
+  }
+
+  return output;
+}
+
+function rewriteSingleSvgEmbed(
+  embedContent: string,
+  sourcePath: string,
+  resolveLinkPath: LinkResolver,
+): string | null {
+  const linkPath = extractEmbedLinkPath(embedContent);
+  if (!linkPath || !isSvgPath(linkPath)) {
+    return null;
+  }
+
+  const resolvedPath = resolveLinkPath(linkPath);
+  const imagePath = resolvedPath
+    ? toRelativeVaultPath(sourcePath, resolvedPath)
+    : linkPath;
+
+  return `![](${formatMarkdownDestination(imagePath)})`;
+}
+
+function extractEmbedLinkPath(embedContent: string): string {
+  const raw = embedContent.trim();
+  const pipeIndex = raw.indexOf('|');
+  return (pipeIndex === -1 ? raw : raw.slice(0, pipeIndex)).trim();
+}
+
+function isSvgPath(path: string): boolean {
+  const clean = path.split('|')[0]?.split('#')[0]?.split('?')[0] ?? path;
+  return clean.toLowerCase().endsWith('.svg');
+}
+
+function toRelativeVaultPath(sourcePath: string, targetPath: string): string {
+  const sourceDir = dirname(normalizeVaultPath(sourcePath));
+  const from = splitVaultPath(sourceDir);
+  const to = splitVaultPath(normalizeVaultPath(targetPath));
+
+  let commonLength = 0;
+  while (
+    commonLength < from.length &&
+    commonLength < to.length &&
+    from[commonLength] === to[commonLength]
+  ) {
+    commonLength += 1;
+  }
+
+  const up = Array(Math.max(0, from.length - commonLength)).fill('..');
+  const down = to.slice(commonLength);
+  const relative = [...up, ...down].join('/');
+
+  return relative || basename(targetPath);
+}
+
+function normalizeVaultPath(path: string): string {
+  const segments = path.split('/');
+  const resolved: string[] = [];
+
+  for (const segment of segments) {
+    if (!segment || segment === '.') {
+      continue;
+    }
+    if (segment === '..') {
+      resolved.pop();
+      continue;
+    }
+    resolved.push(segment);
+  }
+
+  return resolved.join('/');
+}
+
+function dirname(path: string): string {
+  const lastSlash = path.lastIndexOf('/');
+  return lastSlash === -1 ? '' : path.slice(0, lastSlash);
+}
+
+function basename(path: string): string {
+  const lastSlash = path.lastIndexOf('/');
+  return lastSlash === -1 ? path : path.slice(lastSlash + 1);
+}
+
+function splitVaultPath(path: string): string[] {
+  return path ? path.split('/').filter(Boolean) : [];
+}
+
+function formatMarkdownDestination(path: string): string {
+  return /[\s()<>]/.test(path) ? `<${path}>` : path;
+}
+
+function countRun(text: string, start: number, char: string): number {
+  let count = 0;
+  while (text[start + count] === char) {
+    count += 1;
+  }
+  return count;
+}

--- a/obsidian/src/host/preview-view.ts
+++ b/obsidian/src/host/preview-view.ts
@@ -11,6 +11,7 @@
 import { ItemView, WorkspaceLeaf, TFile, Menu, Notice } from 'obsidian';
 import type MarkdownViewerPlugin from './main';
 import { getFileType } from '../../../src/utils/file-wrapper';
+import { rewriteObsidianSvgEmbeds } from './obsidian-svg-embed-rewrite';
 
 // Viewer module — runs in same process, no iframe
 import { initializeViewer, obsidianHostTransport } from '../webview/main';
@@ -140,7 +141,8 @@ export class MarkdownPreviewView extends ItemView {
   }
 
   private async sendFileContent(file: TFile): Promise<void> {
-    const content = await this.app.vault.read(file);
+    const rawContent = await this.app.vault.read(file);
+    const content = this.preprocessMarkdownContent(rawContent, file);
 
     // Build resource base URI for image path resolution.
     // Use a placeholder filename so getResourcePath returns a proper app:// URL
@@ -161,6 +163,17 @@ export class MarkdownPreviewView extends ItemView {
       filename: file.name,
       documentPath: file.path,
       documentBaseUri,
+    });
+  }
+
+  private preprocessMarkdownContent(content: string, file: TFile): string {
+    if (file.extension !== 'md' && file.extension !== 'markdown') {
+      return content;
+    }
+
+    return rewriteObsidianSvgEmbeds(content, file.path, (linkPath) => {
+      const target = this.app.metadataCache.getFirstLinkpathDest(linkPath, file.path);
+      return target?.path ?? null;
     });
   }
 

--- a/test/obsidian-svg-embed-rewrite.test.js
+++ b/test/obsidian-svg-embed-rewrite.test.js
@@ -1,0 +1,55 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { rewriteObsidianSvgEmbeds } from '../obsidian/src/host/obsidian-svg-embed-rewrite.ts';
+
+describe('rewriteObsidianSvgEmbeds', () => {
+  it('rewrites relative svg embeds into markdown images', () => {
+    const input = '![[assets/diagram.svg]]';
+    const output = rewriteObsidianSvgEmbeds(input, 'notes/spec.md', () => 'notes/assets/diagram.svg');
+
+    assert.strictEqual(output, '![](assets/diagram.svg)');
+  });
+
+  it('rewrites resolved vault links to a relative markdown path', () => {
+    const input = '![[diagram.svg]]';
+    const output = rewriteObsidianSvgEmbeds(input, 'notes/specs/doc.md', () => 'assets/diagram.svg');
+
+    assert.strictEqual(output, '![](../../assets/diagram.svg)');
+  });
+
+  it('strips obsidian embed options before rewriting', () => {
+    const input = '![[assets/diagram.svg|320]]';
+    const output = rewriteObsidianSvgEmbeds(input, 'notes/spec.md', () => 'notes/assets/diagram.svg');
+
+    assert.strictEqual(output, '![](assets/diagram.svg)');
+  });
+
+  it('leaves non-svg embeds unchanged', () => {
+    const input = '![[assets/diagram.png]]';
+    const output = rewriteObsidianSvgEmbeds(input, 'notes/spec.md', () => 'notes/assets/diagram.png');
+
+    assert.strictEqual(output, input);
+  });
+
+  it('does not rewrite fenced code blocks', () => {
+    const input = '```md\n![[assets/diagram.svg]]\n```\n\n![[assets/diagram.svg]]';
+    const output = rewriteObsidianSvgEmbeds(input, 'notes/spec.md', () => 'notes/assets/diagram.svg');
+
+    assert.strictEqual(output, '```md\n![[assets/diagram.svg]]\n```\n\n![](assets/diagram.svg)');
+  });
+
+  it('does not rewrite inline code spans', () => {
+    const input = '`![[assets/diagram.svg]]` and ![[assets/diagram.svg]]';
+    const output = rewriteObsidianSvgEmbeds(input, 'notes/spec.md', () => 'notes/assets/diagram.svg');
+
+    assert.strictEqual(output, '`![[assets/diagram.svg]]` and ![](assets/diagram.svg)');
+  });
+
+  it('wraps destinations with spaces in angle brackets', () => {
+    const input = '![[assets/architecture diagram.svg]]';
+    const output = rewriteObsidianSvgEmbeds(input, 'notes/spec.md', () => 'notes/assets/architecture diagram.svg');
+
+    assert.strictEqual(output, '![](<assets/architecture diagram.svg>)');
+  });
+});


### PR DESCRIPTION
## Summary
- rewrite Obsidian `![[...svg]]` embeds into standard Markdown image syntax before sending content to the shared viewer
- resolve wikilink targets through Obsidian metadata so bare filenames still point at the correct vault file
- add focused regression coverage for SVG embeds, code fences, inline code, and spaced paths

## Verification
- `node --test test/obsidian-svg-embed-rewrite.test.js`
- `npm run build:obsidian`
