### PR TITLE
fix: prevent double injection and implement dynamic "View as Raw" toggle

### DIFF
--- a/chrome/src/host/background.ts
+++ b/chrome/src/host/background.ts
@@ -708,7 +708,7 @@ chrome.runtime.onMessage.addListener((message: BackgroundMessage, sender, sendRe
   // New service envelope: dynamic content script injection (preferred)
   if (isRequestEnvelope(message) && message.type === 'INJECT_CONTENT_SCRIPT') {
     const injectionUrl = (message.payload as { url?: string })?.url;
-    handleContentScriptInjection(sender.tab?.id || 0, injectionUrl)
+    handleContentScriptInjection(sender.tab?.id || 0, !!injectionUrl)
       .then(() => {
         const tabId = sender.tab?.id;
         if (tabId) {
@@ -1249,11 +1249,18 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
           });
         } else {
           // Current page - always run html-to-markdown converter first
-          handleContentScriptInjection(tabId, true).then(() => {
-            injectedTabs.add(tabId);
-            updateContextMenu(tabId);
-          }).catch((error) => {
-            console.error('Failed to inject content script:', error);
+          chrome.scripting.executeScript({
+            target: { tabId },
+            func: () => {
+              try { sessionStorage.removeItem('markdownViewerRawOverride'); } catch (e) {}
+            }
+          }).finally(() => {
+            handleContentScriptInjection(tabId, true).then(() => {
+              injectedTabs.add(tabId);
+              updateContextMenu(tabId);
+            }).catch((error) => {
+              console.error('Failed to inject content script:', error);
+            });
           });
         }
       } else {

--- a/chrome/src/host/background.ts
+++ b/chrome/src/host/background.ts
@@ -710,6 +710,13 @@ chrome.runtime.onMessage.addListener((message: BackgroundMessage, sender, sendRe
     const injectionUrl = (message.payload as { url?: string })?.url;
     handleContentScriptInjection(sender.tab?.id || 0, injectionUrl)
       .then(() => {
+        const tabId = sender.tab?.id;
+        if (tabId) {
+          injectedTabs.add(tabId);
+          if (sender.tab?.active) {
+            updateContextMenu(tabId);
+          }
+        }
         sendResponseEnvelope(message.id, sendResponse, { ok: true, data: { success: true } });
       })
       .catch((error) => {
@@ -1096,6 +1103,9 @@ function abortUploadSession(token: string | undefined): void {
   }
 }
 
+// Track tabs that have the viewer injected
+const injectedTabs = new Set<number>();
+
 // Listen for settings changes to update cache manager
 chrome.storage.onChanged.addListener((changes, areaName) => {
   if (areaName === 'local' && changes.markdownViewerSettings) {
@@ -1113,13 +1123,19 @@ chrome.storage.onChanged.addListener((changes, areaName) => {
     
     // Update context menu when locale changes
     if (newSettings && 'preferredLocale' in newSettings) {
-      updateContextMenu();
+      chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+        const activeTabId = tabs[0]?.id;
+        updateContextMenu(activeTabId);
+      });
     }
   }
 });
 
 // Get localized menu title based on user settings
-async function getMenuTitle(): Promise<string> {
+async function getMenuTitle(isRaw = false): Promise<string> {
+  const key = isRaw ? 'contextMenu_viewAsRaw' : 'contextMenu_viewAsMarkdown';
+  const defaultText = isRaw ? 'View as Raw' : 'View as Markdown';
+
   try {
     const result = await chrome.storage.local.get(['markdownViewerSettings']);
     const settings = result?.markdownViewerSettings as { preferredLocale?: string } | undefined;
@@ -1131,7 +1147,7 @@ async function getMenuTitle(): Promise<string> {
         const localeUrl = chrome.runtime.getURL(`_locales/${preferredLocale}/messages.json`);
         const response = await fetch(localeUrl);
         const messages = await response.json();
-        const message = messages['contextMenu_viewAsMarkdown']?.message;
+        const message = messages[key]?.message;
         if (message) {
           return message;
         }
@@ -1145,7 +1161,7 @@ async function getMenuTitle(): Promise<string> {
   }
   
   // Default to browser locale
-  return chrome.i18n.getMessage('contextMenu_viewAsMarkdown') || 'View as Markdown';
+  return chrome.i18n.getMessage(key) || defaultText;
 }
 
 // Initialize context menu for viewing any file as markdown
@@ -1171,9 +1187,10 @@ async function initializeContextMenu(): Promise<void> {
 }
 
 // Update context menu when settings change
-async function updateContextMenu(): Promise<void> {
+async function updateContextMenu(tabId?: number): Promise<void> {
   try {
-    const title = await getMenuTitle();
+    const isRaw = tabId !== undefined ? injectedTabs.has(tabId) : false;
+    const title = await getMenuTitle(isRaw);
     await chrome.contextMenus.update('view-as-markdown', { title });
   } catch (error) {
     // Menu might not exist yet, ignore
@@ -1183,9 +1200,28 @@ async function updateContextMenu(): Promise<void> {
   }
 }
 
+chrome.tabs.onActivated.addListener(({ tabId }) => {
+  updateContextMenu(tabId);
+});
+
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  if (changeInfo.status === 'loading') {
+    // If the tab is reloading/navigating, clear the injection state
+    injectedTabs.delete(tabId);
+    if (tab.active) {
+      updateContextMenu(tabId);
+    }
+  }
+});
+
+chrome.tabs.onRemoved.addListener((tabId) => {
+  injectedTabs.delete(tabId);
+});
+
 // Handle context menu clicks
 chrome.contextMenus.onClicked.addListener((info, tab) => {
   if (info.menuItemId === 'view-as-markdown' && tab?.id) {
+    const tabId = tab.id;
     let targetUrl = '';
     
     // Get the URL to preview
@@ -1199,13 +1235,30 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
       const isCurrentPage = targetUrl === tab.url;
       
       if (isCurrentPage) {
-        // Current page - always run html-to-markdown converter first
-        handleContentScriptInjection(tab.id, true).catch((error) => {
-          console.error('Failed to inject content script:', error);
-        });
+        if (injectedTabs.has(tabId)) {
+          // Restore original view using message passing to content script first,
+          // then reload if it fails (as fallback).
+          chrome.tabs.sendMessage(tabId, { type: 'RESTORE_ORIGINAL_VIEW' }).then(() => {
+            injectedTabs.delete(tabId);
+            updateContextMenu(tabId);
+          }).catch((error) => {
+            console.error('Failed to restore original view:', error);
+            // Fallback: reload page
+            injectedTabs.delete(tabId);
+            chrome.tabs.reload(tabId);
+          });
+        } else {
+          // Current page - always run html-to-markdown converter first
+          handleContentScriptInjection(tabId, true).then(() => {
+            injectedTabs.add(tabId);
+            updateContextMenu(tabId);
+          }).catch((error) => {
+            console.error('Failed to inject content script:', error);
+          });
+        }
       } else {
         // Navigate current tab to the target URL
-        chrome.tabs.update(tab.id, { url: targetUrl });
+        chrome.tabs.update(tabId, { url: targetUrl });
       }
     }
   }

--- a/chrome/src/webview/content-detector.ts
+++ b/chrome/src/webview/content-detector.ts
@@ -109,6 +109,15 @@ function hidePageContent(): void {
  * Inject the main content script
  */
 function injectContentScript(): void {
+  // If user explicitly marked this session to view as raw, abort.
+  try {
+    if (sessionStorage.getItem('markdownViewerRawOverride') === '1') {
+      return;
+    }
+  } catch (e) {
+    // sessionStorage access denied
+  }
+
   // Hide content immediately before injection to prevent flashing
   hidePageContent();
 

--- a/chrome/src/webview/html-to-markdown.ts
+++ b/chrome/src/webview/html-to-markdown.ts
@@ -62,7 +62,7 @@ if (window.__markdownViewerInjected) {
       const reader = new Readability(documentClone);
       const article = reader.parse();
       if (article) {
-        articleContent = article.content;
+        articleContent = article.content || null;
         if (article.title) articleTitle = article.title;
       }
     }
@@ -99,7 +99,7 @@ if (window.__markdownViewerInjected) {
     'script',
     'style',
     'noscript',
-    'svg',
+    'svg' as any,
     'iframe',
     'canvas',
     'form',

--- a/chrome/src/webview/html-to-markdown.ts
+++ b/chrome/src/webview/html-to-markdown.ts
@@ -22,10 +22,14 @@ export interface HtmlConvertedMarkdown {
 declare global {
   interface Window {
     __mvHtmlConvertedMarkdown?: HtmlConvertedMarkdown;
+    __markdownViewerInjected?: boolean;
   }
 }
 
-function convertHtmlPageToMarkdown(): HtmlConvertedMarkdown | null {
+if (window.__markdownViewerInjected) {
+  console.log('[html-to-markdown] Markdown Viewer already injected, skipping DOM convert.');
+} else {
+  function convertHtmlPageToMarkdown(): HtmlConvertedMarkdown | null {
   // Self-detect: only convert if the page is a rendered HTML document.
   // For raw files (text/plain, application/octet-stream, etc.) the viewer
   // can render them directly from document.body.textContent.
@@ -132,9 +136,10 @@ function convertHtmlPageToMarkdown(): HtmlConvertedMarkdown | null {
   };
 }
 
-// Run immediately when injected and expose the result on window.
-// Returns null for non-HTML pages so the viewer falls back to raw textContent.
-const result = convertHtmlPageToMarkdown();
-if (result) {
-  window.__mvHtmlConvertedMarkdown = result;
+  // Run immediately when injected and expose the result on window.
+  // Returns null for non-HTML pages so the viewer falls back to raw textContent.
+  const result = convertHtmlPageToMarkdown();
+  if (result) {
+    window.__mvHtmlConvertedMarkdown = result;
+  }
 }

--- a/chrome/src/webview/main.ts
+++ b/chrome/src/webview/main.ts
@@ -5,7 +5,6 @@ import { initializeViewerBase } from '../../../src/core/viewer/viewer-bootstrap'
 
 declare global {
   interface Window {
-    __markdownViewerOriginalNode?: Node;
     __markdownViewerOriginalScroll?: { x: number; y: number };
     __markdownViewerInjected?: boolean;
     __markdownViewerRestoreHandler?: (message: any) => void;
@@ -17,24 +16,25 @@ if (window.__markdownViewerInjected) {
 } else {
   window.__markdownViewerInjected = true;
   // Save original DOM and scroll position BEFORE viewer replaces the body
-  window.__markdownViewerOriginalNode = document.documentElement.cloneNode(true);
   window.__markdownViewerOriginalScroll = { x: window.scrollX, y: window.scrollY };
 
   // Listen for restore message
   const handleMessage = (message: any) => {
-    if (message?.type === 'RESTORE_ORIGINAL_VIEW' && window.__markdownViewerOriginalNode) {
-      // Restore the DOM
-      document.replaceChild(window.__markdownViewerOriginalNode, document.documentElement);
-      
-      // Restore scroll position
-      window.scrollTo(
-        window.__markdownViewerOriginalScroll?.x || 0,
-        window.__markdownViewerOriginalScroll?.y || 0
-      );
-      
+    if (message?.type === 'RESTORE_ORIGINAL_VIEW') {
       // Cleanup
       window.__markdownViewerInjected = false;
       chrome.runtime.onMessage.removeListener(handleMessage);
+      
+      // Set override flag for content-detector so it doesn't automatically re-inject on reload
+      try {
+        sessionStorage.setItem('markdownViewerRawOverride', '1');
+      } catch (e) {
+        // storage access might be blocked by restrictive settings
+      }
+
+      // Instead of complex DOM manipulation which breaks React and Next.js, 
+      // the safest way to restore complex JS applications is natively reloading the page.
+      window.location.reload();
     }
   };
   chrome.runtime.onMessage.addListener(handleMessage);

--- a/chrome/src/webview/main.ts
+++ b/chrome/src/webview/main.ts
@@ -3,12 +3,49 @@ import { platform } from './index';
 import { startViewer } from './viewer-main';
 import { initializeViewerBase } from '../../../src/core/viewer/viewer-bootstrap';
 
-void initializeViewerBase(platform).then((pluginRenderer) => {
-  startViewer({
-    platform,
-    pluginRenderer,
-    themeConfigRenderer: platform.renderer,
+declare global {
+  interface Window {
+    __markdownViewerOriginalNode?: Node;
+    __markdownViewerOriginalScroll?: { x: number; y: number };
+    __markdownViewerInjected?: boolean;
+    __markdownViewerRestoreHandler?: (message: any) => void;
+  }
+}
+
+if (window.__markdownViewerInjected) {
+  console.log('[main] Markdown Viewer already injected.');
+} else {
+  window.__markdownViewerInjected = true;
+  // Save original DOM and scroll position BEFORE viewer replaces the body
+  window.__markdownViewerOriginalNode = document.documentElement.cloneNode(true);
+  window.__markdownViewerOriginalScroll = { x: window.scrollX, y: window.scrollY };
+
+  // Listen for restore message
+  const handleMessage = (message: any) => {
+    if (message?.type === 'RESTORE_ORIGINAL_VIEW' && window.__markdownViewerOriginalNode) {
+      // Restore the DOM
+      document.replaceChild(window.__markdownViewerOriginalNode, document.documentElement);
+      
+      // Restore scroll position
+      window.scrollTo(
+        window.__markdownViewerOriginalScroll?.x || 0,
+        window.__markdownViewerOriginalScroll?.y || 0
+      );
+      
+      // Cleanup
+      window.__markdownViewerInjected = false;
+      chrome.runtime.onMessage.removeListener(handleMessage);
+    }
+  };
+  chrome.runtime.onMessage.addListener(handleMessage);
+
+  void initializeViewerBase(platform).then((pluginRenderer) => {
+    startViewer({
+      platform,
+      pluginRenderer,
+      themeConfigRenderer: platform.renderer,
+    });
+  }).catch((error) => {
+    console.error('[main] viewer base init failed', error);
   });
-}).catch((error) => {
-  console.error('[main] viewer base init failed', error);
-});
+}

--- a/src/_locales/be/messages.json
+++ b/src/_locales/be/messages.json
@@ -694,5 +694,9 @@
   "zoom": {
     "message": "Маштаб",
     "description": "Menu item for zoom"
+  },
+  "contextMenu_viewAsRaw": {
+    "message": "View as Raw",
+    "description": "Context menu item to restore the page to its original state"
   }
 }

--- a/src/_locales/da/messages.json
+++ b/src/_locales/da/messages.json
@@ -694,5 +694,9 @@
   "zoom": {
     "message": "Zoom",
     "description": "Menu item for zoom"
+  },
+  "contextMenu_viewAsRaw": {
+    "message": "View as Raw",
+    "description": "Context menu item to restore the page to its original state"
   }
 }

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -694,5 +694,9 @@
   "zoom": {
     "message": "Zoom",
     "description": "Menu item for zoom"
+  },
+  "contextMenu_viewAsRaw": {
+    "message": "View as Raw",
+    "description": "Context menu item to restore the page to its original state"
   }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -694,5 +694,9 @@
   "zoom": {
     "message": "Zoom",
     "description": "Menu item for zoom"
+  },
+  "contextMenu_viewAsRaw": {
+    "message": "View as Raw",
+    "description": "Context menu item to restore the page to its original state"
   }
 }

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -694,5 +694,9 @@
   "zoom": {
     "message": "Zoom",
     "description": "Menu item for zoom"
+  },
+  "contextMenu_viewAsRaw": {
+    "message": "View as Raw",
+    "description": "Context menu item to restore the page to its original state"
   }
 }

--- a/src/_locales/et/messages.json
+++ b/src/_locales/et/messages.json
@@ -694,5 +694,9 @@
   "zoom": {
     "message": "Suum",
     "description": "Menu item for zoom"
+  },
+  "contextMenu_viewAsRaw": {
+    "message": "View as Raw",
+    "description": "Context menu item to restore the page to its original state"
   }
 }

--- a/src/_locales/fi/messages.json
+++ b/src/_locales/fi/messages.json
@@ -694,5 +694,9 @@
   "zoom": {
     "message": "Zoomaus",
     "description": "Menu item for zoom"
+  },
+  "contextMenu_viewAsRaw": {
+    "message": "View as Raw",
+    "description": "Context menu item to restore the page to its original state"
   }
 }

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -694,5 +694,9 @@
   "zoom": {
     "message": "Zoom",
     "description": "Menu item for zoom"
+  },
+  "contextMenu_viewAsRaw": {
+    "message": "View as Raw",
+    "description": "Context menu item to restore the page to its original state"
   }
 }

--- a/src/_locales/hi/messages.json
+++ b/src/_locales/hi/messages.json
@@ -694,5 +694,9 @@
   "zoom": {
     "message": "ज़ूम",
     "description": "Menu item for zoom"
+  },
+  "contextMenu_viewAsRaw": {
+    "message": "View as Raw",
+    "description": "Context menu item to restore the page to its original state"
   }
 }

--- a/src/_locales/id/messages.json
+++ b/src/_locales/id/messages.json
@@ -694,5 +694,9 @@
   "zoom": {
     "message": "Zoom",
     "description": "Menu item for zoom"
+  },
+  "contextMenu_viewAsRaw": {
+    "message": "View as Raw",
+    "description": "Context menu item to restore the page to its original state"
   }
 }

--- a/src/_locales/it/messages.json
+++ b/src/_locales/it/messages.json
@@ -694,5 +694,9 @@
   "zoom": {
     "message": "Zoom",
     "description": "Menu item for zoom"
+  },
+  "contextMenu_viewAsRaw": {
+    "message": "View as Raw",
+    "description": "Context menu item to restore the page to its original state"
   }
 }

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -694,5 +694,9 @@
   "zoom": {
     "message": "ズーム",
     "description": "Menu item for zoom"
+  },
+  "contextMenu_viewAsRaw": {
+    "message": "View as Raw",
+    "description": "Context menu item to restore the page to its original state"
   }
 }

--- a/src/_locales/ko/messages.json
+++ b/src/_locales/ko/messages.json
@@ -694,5 +694,9 @@
   "zoom": {
     "message": "확대/축소",
     "description": "Menu item for zoom"
+  },
+  "contextMenu_viewAsRaw": {
+    "message": "View as Raw",
+    "description": "Context menu item to restore the page to its original state"
   }
 }

--- a/src/_locales/lt/messages.json
+++ b/src/_locales/lt/messages.json
@@ -694,5 +694,9 @@
   "zoom": {
     "message": "Mastelis",
     "description": "Menu item for zoom"
+  },
+  "contextMenu_viewAsRaw": {
+    "message": "View as Raw",
+    "description": "Context menu item to restore the page to its original state"
   }
 }

--- a/src/_locales/ms/messages.json
+++ b/src/_locales/ms/messages.json
@@ -694,5 +694,9 @@
   "zoom": {
     "message": "Zum",
     "description": "Menu item for zoom"
+  },
+  "contextMenu_viewAsRaw": {
+    "message": "View as Raw",
+    "description": "Context menu item to restore the page to its original state"
   }
 }

--- a/src/_locales/nl/messages.json
+++ b/src/_locales/nl/messages.json
@@ -694,5 +694,9 @@
   "zoom": {
     "message": "Zoomen",
     "description": "Menu item for zoom"
+  },
+  "contextMenu_viewAsRaw": {
+    "message": "View as Raw",
+    "description": "Context menu item to restore the page to its original state"
   }
 }

--- a/src/_locales/no/messages.json
+++ b/src/_locales/no/messages.json
@@ -694,5 +694,9 @@
   "zoom": {
     "message": "Zoom",
     "description": "Menu item for zoom"
+  },
+  "contextMenu_viewAsRaw": {
+    "message": "View as Raw",
+    "description": "Context menu item to restore the page to its original state"
   }
 }

--- a/src/_locales/pl/messages.json
+++ b/src/_locales/pl/messages.json
@@ -694,5 +694,9 @@
   "zoom": {
     "message": "Powiększenie",
     "description": "Menu item for zoom"
+  },
+  "contextMenu_viewAsRaw": {
+    "message": "View as Raw",
+    "description": "Context menu item to restore the page to its original state"
   }
 }

--- a/src/_locales/pt_BR/messages.json
+++ b/src/_locales/pt_BR/messages.json
@@ -694,5 +694,9 @@
   "zoom": {
     "message": "Zoom",
     "description": "Menu item for zoom"
+  },
+  "contextMenu_viewAsRaw": {
+    "message": "View as Raw",
+    "description": "Context menu item to restore the page to its original state"
   }
 }

--- a/src/_locales/pt_PT/messages.json
+++ b/src/_locales/pt_PT/messages.json
@@ -694,5 +694,9 @@
   "zoom": {
     "message": "Zoom",
     "description": "Menu item for zoom"
+  },
+  "contextMenu_viewAsRaw": {
+    "message": "View as Raw",
+    "description": "Context menu item to restore the page to its original state"
   }
 }

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -694,5 +694,9 @@
   "zoom": {
     "message": "Масштаб",
     "description": "Menu item for zoom"
+  },
+  "contextMenu_viewAsRaw": {
+    "message": "View as Raw",
+    "description": "Context menu item to restore the page to its original state"
   }
 }

--- a/src/_locales/sv/messages.json
+++ b/src/_locales/sv/messages.json
@@ -694,5 +694,9 @@
   "zoom": {
     "message": "Zoom",
     "description": "Menu item for zoom"
+  },
+  "contextMenu_viewAsRaw": {
+    "message": "View as Raw",
+    "description": "Context menu item to restore the page to its original state"
   }
 }

--- a/src/_locales/th/messages.json
+++ b/src/_locales/th/messages.json
@@ -694,5 +694,9 @@
   "zoom": {
     "message": "ซูม",
     "description": "Menu item for zoom"
+  },
+  "contextMenu_viewAsRaw": {
+    "message": "View as Raw",
+    "description": "Context menu item to restore the page to its original state"
   }
 }

--- a/src/_locales/tr/messages.json
+++ b/src/_locales/tr/messages.json
@@ -694,5 +694,9 @@
   "zoom": {
     "message": "Yakınlaştır",
     "description": "Menu item for zoom"
+  },
+  "contextMenu_viewAsRaw": {
+    "message": "View as Raw",
+    "description": "Context menu item to restore the page to its original state"
   }
 }

--- a/src/_locales/uk/messages.json
+++ b/src/_locales/uk/messages.json
@@ -694,5 +694,9 @@
   "zoom": {
     "message": "Масштаб",
     "description": "Menu item for zoom"
+  },
+  "contextMenu_viewAsRaw": {
+    "message": "View as Raw",
+    "description": "Context menu item to restore the page to its original state"
   }
 }

--- a/src/_locales/vi/messages.json
+++ b/src/_locales/vi/messages.json
@@ -694,5 +694,9 @@
   "zoom": {
     "message": "Thu phóng",
     "description": "Menu item for zoom"
+  },
+  "contextMenu_viewAsRaw": {
+    "message": "View as Raw",
+    "description": "Context menu item to restore the page to its original state"
   }
 }

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -694,5 +694,9 @@
   "zoom": {
     "message": "缩放",
     "description": "Menu item for zoom"
+  },
+  "contextMenu_viewAsRaw": {
+    "message": "View as Raw",
+    "description": "Context menu item to restore the page to its original state"
   }
 }

--- a/src/_locales/zh_TW/messages.json
+++ b/src/_locales/zh_TW/messages.json
@@ -694,5 +694,9 @@
   "zoom": {
     "message": "縮放",
     "description": "Menu item for zoom"
+  },
+  "contextMenu_viewAsRaw": {
+    "message": "View as Raw",
+    "description": "Context menu item to restore the page to its original state"
   }
 }


### PR DESCRIPTION
Fixes Issue: https://github.com/markdown-viewer/markdown-viewer-extension/issues/69 

**What's changed?** 

This PR fully resolves the duplicate injection bug and introduces the requested dynamic context menu toggle. 

**Dynamic Context Menu Toggle**: 
The extension safely tracks injected tabs using a Set (injectedTabs) in the background service worker, combined with chrome.tabs lifecycle listeners. The context menu dynamically toggles between **"View as Markdown"** and **"View as Raw"**. This fundamentally prevents the duplicate script execution bug reported in the issue. 

**Safe "View as Raw" Restoration (CSP & SPA Compliant)**: 
Implemented a seamless restorer using a sessionStorage flag (markdownViewerRawOverride) + native location.reload(). content-detector.ts checks this session flag to skip auto-injection, while background.ts safely clears the flag when toggling back to Markdown. 

**Upstream Alignment & TS Fixes**: 

Resolved strict TypeScript compilation errors triggered by recent upstream updates in HTML parsing (fixed !!injectionUrl coercion, article.content nullability, and Turndown 'svg' typing). 

Why sessionStorage + reload() instead of DOM cloning (as originally proposed in the issue)? While the issue originally proposed saving document.documentElement.cloneNode(true) and replacing it back to prevent reloads, extensive testing revealed this is highly destructive for modern single-page applications (SPAs): 

1. React State Crashes: Manually wiping and replacing the DOM detaches the real DOM from the Virtual DOM in frameworks like React and Next.js. This causes fatal render/unmount errors (e.g., Cannot read properties of null (reading 'removeChild')). 
2. CSP Violations: Re-inserting original <script> tags triggers strict script-src and wasm-unsafe-eval Content Security Policy blocks on secure sites. 

By using the session flag and a native reload, we allow the browser to naturally and safely restore the original page state without hitting CSP blocks or breaking framework lifecycles.