### PR TITLE
feat: add click-to-zoom diagram lightbox

### DIFF
--- a/chrome/src/transports/chrome-runtime-transport.ts
+++ b/chrome/src/transports/chrome-runtime-transport.ts
@@ -37,11 +37,14 @@ export class ChromeRuntimeTransport implements MessageTransport {
   }
 
   async send(message: unknown): Promise<unknown> {
+    if (!chrome.runtime?.id) return undefined;
+
     // Firefox browser.runtime.sendMessage returns a Promise
     // Chrome also supports Promise in modern versions
     try {
       return await runtimeApi.runtime.sendMessage(message);
     } catch (error) {
+      if (!chrome.runtime?.id) return undefined;
       // Fallback for older Chrome callback style
       return new Promise((resolve, reject) => {
         chrome.runtime.sendMessage(message, (response) => {
@@ -57,22 +60,28 @@ export class ChromeRuntimeTransport implements MessageTransport {
 
   onMessage(handler: (message: unknown, meta?: TransportMeta) => void): Unsubscribe {
     this.listener = (message, sender, sendResponse) => {
+      if (!chrome.runtime?.id) return false;
       const meta: TransportMeta = {
         raw: sender,
         respond: sendResponse,
       };
       handler(message, meta);
-      // Return willRespond to indicate whether we'll send an async response.
-      // Background scripts need true; popup/content scripts need false to
-      // prevent Firefox's "Promised response went out of scope" errors.
       return this.willRespond;
     };
 
-    runtimeApi.runtime.onMessage.addListener(this.listener);
+    try {
+      runtimeApi.runtime.onMessage.addListener(this.listener);
+    } catch {
+      // Context invalidated after extension reload
+    }
 
     return () => {
       if (this.listener) {
-        runtimeApi.runtime.onMessage.removeListener(this.listener);
+        try {
+          runtimeApi.runtime.onMessage.removeListener(this.listener);
+        } catch {
+          // Extension context may be invalidated
+        }
         this.listener = undefined;
       }
     };

--- a/chrome/src/webview/api-impl.ts
+++ b/chrome/src/webview/api-impl.ts
@@ -232,11 +232,15 @@ export class ChromeMessageService {
   }
 
   addListener(handler: (message: unknown) => void): void {
-    chrome.runtime.onMessage.addListener((message) => {
-      // Event-only listener: envelope RPC is handled via send/sendEnvelope.
-      handler(message);
-      return false;
-    });
+    try {
+      chrome.runtime.onMessage.addListener((message) => {
+        if (!chrome.runtime?.id) return false;
+        handler(message);
+        return false;
+      });
+    } catch {
+      // Context invalidated after extension reload
+    }
   }
 }
 

--- a/chrome/src/webview/viewer-main.ts
+++ b/chrome/src/webview/viewer-main.ts
@@ -33,6 +33,7 @@ import {
   setCurrentFileKey,
 } from '../../../src/core/viewer/viewer-host';
 import { setupImageContextMenu } from '../../../src/ui/image-context-menu';
+import { setupDiagramLightbox } from '../../../src/ui/diagram-lightbox';
 
 // Extend Window interface for global access
 declare global {
@@ -1141,11 +1142,15 @@ export async function initializeViewerMain(options: ViewerMainOptions): Promise<
       return;
     }
 
-    chrome.runtime.sendMessage({
-      id: `stop-tracking-${Date.now()}`,
-      type: 'STOP_FILE_TRACKING',
-      payload: { url: activeUrl },
-    });
+    try {
+      chrome.runtime.sendMessage({
+        id: `stop-tracking-${Date.now()}`,
+        type: 'STOP_FILE_TRACKING',
+        payload: { url: activeUrl },
+      });
+    } catch {
+      // Context invalidated after extension reload
+    }
   }
 
   window.addEventListener('beforeunload', () => {
@@ -1184,6 +1189,12 @@ export async function initializeViewerMain(options: ViewerMainOptions): Promise<
           URL.revokeObjectURL(url);
         }, 100);
       },
+      translate: (key) => Localization.translate(key),
+    });
+
+    // Setup diagram lightbox for click-to-zoom (shared cross-platform)
+    setupDiagramLightbox({
+      container: contentContainer,
       translate: (key) => Localization.translate(key),
     });
   }

--- a/mobile/src/webview/main.ts
+++ b/mobile/src/webview/main.ts
@@ -23,6 +23,7 @@ import {
   exportDocxFlow,
 } from '../../../src/core/viewer/viewer-host';
 import { setupImageContextMenu } from '../../../src/ui/image-context-menu';
+import { setupDiagramLightbox } from '../../../src/ui/diagram-lightbox';
 import { findHeadingLine } from '../../../src/utils/heading-slug';
 import { isExternalUrl, splitPathAndFragment } from '../../../src/utils/document-url';
 
@@ -139,6 +140,11 @@ async function initialize(): Promise<void> {
         onDownload: ({ filename, data, mimeType }) => {
           bridge.sendRequest('DOWNLOAD_FILE', { filename, data, mimeType });
         },
+        translate: (key) => Localization.translate(key),
+      });
+
+      setupDiagramLightbox({
+        container: contentContainer,
         translate: (key) => Localization.translate(key),
       });
     }

--- a/src/ui/diagram-lightbox.ts
+++ b/src/ui/diagram-lightbox.ts
@@ -1,0 +1,493 @@
+export interface DiagramLightboxOptions {
+  container: HTMLElement;
+  translate?: (key: string) => string;
+}
+
+const MAX_ZOOM = 8;
+const ZOOM_STEP = 0.25;
+
+let cssInjected = false;
+
+function injectCSS(): void {
+  if (cssInjected) return;
+  cssInjected = true;
+
+  const style = document.createElement('style');
+  style.textContent = `
+.mv-lightbox-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 100000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.95); /* overridden at runtime to match theme */
+  opacity: 0;
+  transition: opacity 150ms ease;
+  cursor: default;
+  touch-action: none;
+}
+
+.mv-lightbox-overlay.mv-lightbox-visible {
+  opacity: 1;
+}
+
+.mv-lightbox-viewport {
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+  height: 100%;
+  cursor: grab;
+}
+
+.mv-lightbox-viewport.mv-lightbox-dragging {
+  cursor: grabbing;
+}
+
+.mv-lightbox-img {
+  position: absolute;
+  top: 0;
+  left: 0;
+  max-width: none;
+  max-height: none;
+  transform-origin: 0 0;
+  user-select: none;
+  -webkit-user-select: none;
+  pointer-events: none;
+}
+
+.mv-lightbox-controls {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 10px;
+  background: rgba(0, 0, 0, 0.7);
+  border-radius: 8px;
+  color: #fff;
+  backdrop-filter: blur(8px);
+  font-size: 13px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  z-index: 100001;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.mv-lightbox-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: #fff;
+  font-size: 18px;
+  cursor: pointer;
+  transition: background 100ms;
+}
+
+.mv-lightbox-btn:hover {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.mv-lightbox-zoom-label {
+  min-width: 48px;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+  cursor: pointer;
+}
+
+.mv-lightbox-zoom-label:hover {
+  text-decoration: underline;
+}
+
+.mv-lightbox-close {
+  position: fixed;
+  top: 16px;
+  right: 16px;
+  z-index: 100001;
+}
+`;
+  document.head.appendChild(style);
+}
+
+let activeOverlay: HTMLElement | null = null;
+let activeCleanup: (() => void) | null = null;
+
+/**
+ * Set up diagram lightbox on a container element.
+ * Listens for clicks on diagram images and opens a zoom overlay.
+ * Returns a cleanup function.
+ */
+export function setupDiagramLightbox(options: DiagramLightboxOptions): () => void {
+  const { container, translate: translateFn } = options;
+
+  injectCSS();
+
+  function translate(key: string): string {
+    return translateFn?.(key) || fallbackTranslation(key);
+  }
+
+  function onClick(e: MouseEvent): void {
+    if (e.button !== 0) return;
+
+    const target = e.target as HTMLElement;
+    const diagramBlock = target.closest('.diagram-block');
+    const img = diagramBlock
+      ? diagramBlock.querySelector('img') as HTMLImageElement | null
+      : (target.closest('img.diagram-inline') as HTMLImageElement | null);
+
+    if (!img) return;
+
+    e.preventDefault();
+    e.stopPropagation();
+    openLightbox(img, translate);
+  }
+
+  container.addEventListener('click', onClick);
+
+  return () => {
+    container.removeEventListener('click', onClick);
+    closeLightbox();
+  };
+}
+
+function openLightbox(sourceImg: HTMLImageElement, translate: (key: string) => string): void {
+  closeLightbox();
+
+  const overlay = document.createElement('div');
+  overlay.className = 'mv-lightbox-overlay';
+  overlay.style.background = getOverlayBackground();
+
+  const viewport = document.createElement('div');
+  viewport.className = 'mv-lightbox-viewport';
+
+  const img = document.createElement('img');
+  img.className = 'mv-lightbox-img';
+  img.src = sourceImg.src;
+  img.alt = sourceImg.alt || 'Diagram';
+
+  viewport.appendChild(img);
+  overlay.appendChild(viewport);
+  document.body.appendChild(overlay);
+  activeOverlay = overlay;
+
+  const onReady = () => {
+    if (activeOverlay !== overlay) return;
+
+    const state = createZoomState(img, viewport);
+
+    const controls = buildControls(state, translate);
+    const closeBtn = buildCloseButton(translate);
+    overlay.appendChild(controls);
+    overlay.appendChild(closeBtn);
+
+    fitToViewport(state);
+
+    activeCleanup = bindInteractions(state, viewport);
+
+    requestAnimationFrame(() => overlay.classList.add('mv-lightbox-visible'));
+  };
+
+  if (img.complete && img.naturalWidth > 0) {
+    onReady();
+  } else {
+    img.onload = onReady;
+    img.onerror = () => closeLightbox();
+  }
+}
+
+function closeLightbox(): void {
+  if (!activeOverlay) return;
+
+  const overlay = activeOverlay;
+  activeOverlay = null;
+
+  activeCleanup?.();
+  activeCleanup = null;
+
+  overlay.classList.remove('mv-lightbox-visible');
+  overlay.remove();
+}
+
+interface ZoomState {
+  img: HTMLImageElement;
+  viewport: HTMLElement;
+  zoom: number;
+  minZoom: number;
+  panX: number;
+  panY: number;
+  zoomLabel: HTMLElement | null;
+}
+
+function createZoomState(img: HTMLImageElement, viewport: HTMLElement): ZoomState {
+  return { img, viewport, zoom: 1, minZoom: 0.1, panX: 0, panY: 0, zoomLabel: null };
+}
+
+function fitToViewport(state: ZoomState): void {
+  const { img, viewport } = state;
+  const vw = viewport.clientWidth - 48;
+  const vh = viewport.clientHeight - 48;
+  const iw = img.naturalWidth;
+  const ih = img.naturalHeight;
+
+  if (iw === 0 || ih === 0) return;
+
+  const fitZoom = Math.min(vw / iw, vh / ih, 1);
+  state.minZoom = fitZoom * 0.5;
+  state.zoom = fitZoom;
+  state.panX = 0;
+  state.panY = 0;
+  applyTransform(state);
+}
+
+function applyTransform(state: ZoomState): void {
+  const { img, viewport, zoom, panX, panY } = state;
+  const iw = img.naturalWidth * zoom;
+  const ih = img.naturalHeight * zoom;
+  const vw = viewport.clientWidth;
+  const vh = viewport.clientHeight;
+
+  const x = (vw - iw) / 2 + panX;
+  const y = (vh - ih) / 2 + panY;
+
+  img.style.transform = `translate(${x}px, ${y}px) scale(${zoom})`;
+
+  if (state.zoomLabel) {
+    state.zoomLabel.textContent = Math.round(zoom * 100) + '%';
+  }
+}
+
+function zoomAt(state: ZoomState, delta: number, cx: number, cy: number): void {
+  const oldZoom = state.zoom;
+  const newZoom = clamp(oldZoom + delta, state.minZoom, MAX_ZOOM);
+  if (newZoom === oldZoom) return;
+
+  const { viewport, img } = state;
+  const vw = viewport.clientWidth;
+  const vh = viewport.clientHeight;
+  const iw = img.naturalWidth * oldZoom;
+  const ih = img.naturalHeight * oldZoom;
+
+  const imgX = (vw - iw) / 2 + state.panX;
+  const imgY = (vh - ih) / 2 + state.panY;
+
+  const ratio = newZoom / oldZoom;
+  const newImgX = cx - (cx - imgX) * ratio;
+  const newImgY = cy - (cy - imgY) * ratio;
+
+  const newIw = img.naturalWidth * newZoom;
+  const newIh = img.naturalHeight * newZoom;
+
+  state.zoom = newZoom;
+  state.panX = newImgX - (vw - newIw) / 2;
+  state.panY = newImgY - (vh - newIh) / 2;
+
+  applyTransform(state);
+}
+
+function buildControls(state: ZoomState, translate: (key: string) => string): HTMLElement {
+  const controls = document.createElement('div');
+  controls.className = 'mv-lightbox-controls';
+
+  const zoomOut = createButton('−', translate('lightbox_zoom_out'), () => {
+    zoomAt(state, -ZOOM_STEP, state.viewport.clientWidth / 2, state.viewport.clientHeight / 2);
+  });
+
+  const zoomLabel = document.createElement('span');
+  zoomLabel.className = 'mv-lightbox-zoom-label';
+  zoomLabel.textContent = Math.round(state.zoom * 100) + '%';
+  zoomLabel.title = translate('lightbox_fit');
+  zoomLabel.addEventListener('click', () => fitToViewport(state));
+  state.zoomLabel = zoomLabel;
+
+  const zoomIn = createButton('+', translate('lightbox_zoom_in'), () => {
+    zoomAt(state, ZOOM_STEP, state.viewport.clientWidth / 2, state.viewport.clientHeight / 2);
+  });
+
+  controls.appendChild(zoomOut);
+  controls.appendChild(zoomLabel);
+  controls.appendChild(zoomIn);
+
+  return controls;
+}
+
+function buildCloseButton(translate: (key: string) => string): HTMLElement {
+  const btn = createButton('✕', translate('lightbox_close'), () => closeLightbox());
+  btn.classList.add('mv-lightbox-close');
+  return btn;
+}
+
+function createButton(text: string, title: string, onClick: () => void): HTMLButtonElement {
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'mv-lightbox-btn';
+  btn.textContent = text;
+  btn.title = title;
+  btn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    onClick();
+  });
+  return btn;
+}
+
+function bindInteractions(state: ZoomState, viewport: HTMLElement): () => void {
+  const onWheel = (e: WheelEvent) => {
+    e.preventDefault();
+    const rect = viewport.getBoundingClientRect();
+    const cx = e.clientX - rect.left;
+    const cy = e.clientY - rect.top;
+    const delta = e.deltaY < 0 ? ZOOM_STEP : -ZOOM_STEP;
+    zoomAt(state, delta, cx, cy);
+  };
+  viewport.addEventListener('wheel', onWheel, { passive: false });
+
+  // Only one input mode active at a time (browsers synthesize mouse from touch)
+  let mouseDragging = false;
+  let touchDragging = false;
+  let dragStartX = 0;
+  let dragStartY = 0;
+  let panStartX = 0;
+  let panStartY = 0;
+
+  const onMouseDown = (e: MouseEvent) => {
+    if (e.button !== 0) return;
+    mouseDragging = true;
+    dragStartX = e.clientX;
+    dragStartY = e.clientY;
+    panStartX = state.panX;
+    panStartY = state.panY;
+    viewport.classList.add('mv-lightbox-dragging');
+  };
+
+  const onMouseMove = (e: MouseEvent) => {
+    if (!mouseDragging) return;
+    state.panX = panStartX + (e.clientX - dragStartX);
+    state.panY = panStartY + (e.clientY - dragStartY);
+    applyTransform(state);
+  };
+
+  const onMouseUp = (e: MouseEvent) => {
+    if (!mouseDragging) return;
+    mouseDragging = false;
+    viewport.classList.remove('mv-lightbox-dragging');
+
+    // Close if it was a click (no significant drag) on empty viewport area
+    const dx = Math.abs(e.clientX - dragStartX);
+    const dy = Math.abs(e.clientY - dragStartY);
+    if (dx < 5 && dy < 5 && e.target === viewport) {
+      closeLightbox();
+    }
+  };
+
+  viewport.addEventListener('mousedown', onMouseDown);
+  document.addEventListener('mousemove', onMouseMove);
+  document.addEventListener('mouseup', onMouseUp);
+
+  let lastTouchDist = 0;
+
+  const onTouchStart = (e: TouchEvent) => {
+    if (e.touches.length === 2) {
+      lastTouchDist = touchDistance(e.touches);
+    } else if (e.touches.length === 1) {
+      touchDragging = true;
+      dragStartX = e.touches[0].clientX;
+      dragStartY = e.touches[0].clientY;
+      panStartX = state.panX;
+      panStartY = state.panY;
+    }
+  };
+
+  const onTouchMove = (e: TouchEvent) => {
+    e.preventDefault();
+    if (e.touches.length === 2) {
+      const dist = touchDistance(e.touches);
+      const center = touchCenter(e.touches, viewport);
+      const scale = dist / lastTouchDist;
+      const delta = (scale - 1) * state.zoom;
+      zoomAt(state, delta, center.x, center.y);
+      lastTouchDist = dist;
+    } else if (e.touches.length === 1 && touchDragging) {
+      state.panX = panStartX + (e.touches[0].clientX - dragStartX);
+      state.panY = panStartY + (e.touches[0].clientY - dragStartY);
+      applyTransform(state);
+    }
+  };
+
+  const onTouchEnd = () => {
+    touchDragging = false;
+    lastTouchDist = 0;
+  };
+
+  viewport.addEventListener('touchstart', onTouchStart, { passive: false });
+  viewport.addEventListener('touchmove', onTouchMove, { passive: false });
+  viewport.addEventListener('touchend', onTouchEnd);
+
+  const onKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      closeLightbox();
+    } else if (e.key === '+' || e.key === '=') {
+      zoomAt(state, ZOOM_STEP, viewport.clientWidth / 2, viewport.clientHeight / 2);
+    } else if (e.key === '-') {
+      zoomAt(state, -ZOOM_STEP, viewport.clientWidth / 2, viewport.clientHeight / 2);
+    } else if (e.key === '0') {
+      fitToViewport(state);
+    }
+  };
+  document.addEventListener('keydown', onKeyDown);
+
+  return () => {
+    viewport.removeEventListener('wheel', onWheel);
+    viewport.removeEventListener('mousedown', onMouseDown);
+    document.removeEventListener('mousemove', onMouseMove);
+    document.removeEventListener('mouseup', onMouseUp);
+    viewport.removeEventListener('touchstart', onTouchStart);
+    viewport.removeEventListener('touchmove', onTouchMove);
+    viewport.removeEventListener('touchend', onTouchEnd);
+    document.removeEventListener('keydown', onKeyDown);
+  };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function touchDistance(touches: TouchList): number {
+  const dx = touches[0].clientX - touches[1].clientX;
+  const dy = touches[0].clientY - touches[1].clientY;
+  return Math.sqrt(dx * dx + dy * dy);
+}
+
+function touchCenter(touches: TouchList, viewport: HTMLElement): { x: number; y: number } {
+  const rect = viewport.getBoundingClientRect();
+  return {
+    x: (touches[0].clientX + touches[1].clientX) / 2 - rect.left,
+    y: (touches[0].clientY + touches[1].clientY) / 2 - rect.top,
+  };
+}
+
+function getOverlayBackground(): string {
+  const bg = getComputedStyle(document.body).backgroundColor;
+  const match = bg.match(/\d+/g);
+  if (match && match.length >= 3) {
+    const [r, g, b] = match.map(Number);
+    return `rgba(${r}, ${g}, ${b}, 0.95)`;
+  }
+  return 'rgba(255, 255, 255, 0.95)';
+}
+
+const FALLBACK_TRANSLATIONS: Record<string, string> = {
+  lightbox_zoom_in: 'Zoom in',
+  lightbox_zoom_out: 'Zoom out',
+  lightbox_fit: 'Fit to screen',
+  lightbox_close: 'Close',
+};
+
+function fallbackTranslation(key: string): string {
+  return FALLBACK_TRANSLATIONS[key] || key;
+}

--- a/vscode/src/webview/main.ts
+++ b/vscode/src/webview/main.ts
@@ -34,6 +34,7 @@ import { createSettingsPanel, type SettingsPanel, type ThemeOption, type LocaleO
 import { createSearchPanel, type SearchPanel, type HighlightMatch, type SearchOptions } from './search-panel';
 import { createTocPanel, type TocPanel } from '../../../src/ui/toc-panel';
 import { setupImageContextMenu } from '../../../src/ui/image-context-menu';
+import { setupDiagramLightbox } from '../../../src/ui/diagram-lightbox';
 import { createExportMenu, type ExportMenu } from '../../../src/ui/export-menu';
 import { printElement } from '../../../src/ui/print-utils';
 import { isExternalUrl, splitPathAndFragment } from '../../../src/utils/document-url';
@@ -726,6 +727,12 @@ function initializeUI(): void {
       onDownload: ({ filename, data, mimeType }) => {
         vscodeBridge.sendRequest('DOWNLOAD_FILE', { filename, data, mimeType });
       },
+      translate: (key) => Localization.translate(key),
+    });
+
+    // Setup diagram lightbox for click-to-zoom (shared cross-platform)
+    setupDiagramLightbox({
+      container: contentContainer,
       translate: (key) => Localization.translate(key),
     });
   }


### PR DESCRIPTION
## Summary

- Add fullscreen lightbox overlay when clicking any rendered diagram — supports mouse wheel zoom (toward cursor), click-drag pan, touch pinch-to-zoom, and keyboard shortcuts (Esc/+/-/0)
- Theme-adaptive overlay background that matches the current color scheme
- Fix "Extension context invalidated" Chrome error when reloading extension then refreshing the page

Closes https://github.com/markdown-viewer/markdown-viewer-extension/issues/71

## Changes

### New file
- `src/ui/diagram-lightbox.ts` — self-contained lightbox module with zoom/pan/touch/keyboard interactions

### Modified files
- `chrome/src/webview/viewer-main.ts` — integrate lightbox + wrap `stopFileTracking` runtime call in try/catch
- `vscode/src/webview/main.ts` — integrate lightbox
- `mobile/src/webview/main.ts` — integrate lightbox
- `chrome/src/transports/chrome-runtime-transport.ts` — guard all `chrome.runtime` API calls against invalidated context
- `chrome/src/webview/api-impl.ts` — guard `onMessage` listener against invalidated context

## Test plan

- [x] Open a markdown file with Mermaid/PlantUML/Vega/DrawIO diagrams
- [x] Click on a diagram → lightbox opens with theme-matching background
- [x] Scroll wheel to zoom in/out (zoom follows cursor position)
- [x] Click-drag to pan the diagram
- [x] Press `+`/`-` to zoom, `0` to fit, `Esc` to close
- [x] Click on empty area outside diagram to close
- [ ] On mobile: pinch-to-zoom and one-finger pan work
- [x] Reload Chrome extension → reload page → no "Extension context invalidated" error
- [x] Test on Chrome, Firefox, VS Code, and mobile platforms

<img width="1631" height="1022" alt="image" src="https://github.com/user-attachments/assets/62f1cd13-50db-4e22-a120-20ffaf7ae049" />
<img width="1631" height="1027" alt="image" src="https://github.com/user-attachments/assets/b2f4844e-0da9-4bc2-bc93-55bd89fef52c" />
