### PR TITLE
fix: scope SUMMARY.md discovery to repository root and prevent duplicate requests

### DIFF
--- a/chrome/src/webview/ui/gitbook-panel.ts
+++ b/chrome/src/webview/ui/gitbook-panel.ts
@@ -81,6 +81,28 @@ function normalizeRawGitHubRefUrl(url: string): string | null {
   }
 }
 
+function getRepositoryRootPath(url: string): string {
+  try {
+    const parsed = new URL(url);
+    if (parsed.hostname === 'raw.githubusercontent.com') {
+      const segments = parsed.pathname.split('/').filter(Boolean);
+      if (segments.length >= 5 && segments[2] === 'refs') {
+        return `/${segments.slice(0, 5).join('/')}/`;
+      } else if (segments.length >= 3) {
+        return `/${segments.slice(0, 3).join('/')}/`;
+      }
+    } else if (parsed.hostname === 'github.com') {
+      const segments = parsed.pathname.split('/').filter(Boolean);
+      if (segments.length >= 4 && (segments[2] === 'blob' || segments[2] === 'tree')) {
+        return `/${segments.slice(0, 4).join('/')}/`;
+      }
+    }
+    return '/';
+  } catch {
+    return '/';
+  }
+}
+
 function parseGitbookSummary(summaryContent: string, summaryUrl: string): GitbookNavItem[] {
   const items: GitbookNavItem[] = [];
   const lines = summaryContent.split(/\r?\n/);
@@ -172,12 +194,37 @@ async function loadGitbookNavigation(
   }
 
   const summaryNames = ['SUMMARY.md', 'summary.md'];
+  const visitedUrls = new Set<string>();
 
   let depth = 0;
   while (depth <= 20) {
+    let checkedAtLeastOne = false;
+
     for (const summaryName of summaryNames) {
       const relativePath = `${'../'.repeat(depth)}${summaryName}`;
       for (const baseUrl of baseUrls) {
+        let summaryParsedUrl: URL;
+        try {
+          summaryParsedUrl = new URL(relativePath, baseUrl);
+        } catch {
+          continue;
+        }
+
+        const summaryUrl = summaryParsedUrl.href;
+        
+        if (visitedUrls.has(summaryUrl)) {
+          continue;
+        }
+        visitedUrls.add(summaryUrl);
+
+        // Prevent traversing above repository root
+        const repoRoot = getRepositoryRootPath(baseUrl);
+        if (!summaryParsedUrl.pathname.startsWith(repoRoot)) {
+          continue;
+        }
+
+        checkedAtLeastOne = true;
+
         const loaded = await readSummaryByRelativePath(relativePath, baseUrl, readRelativeFile);
         if (!loaded) {
           continue;
@@ -192,6 +239,11 @@ async function loadGitbookNavigation(
           return navItems;
         }
       }
+    }
+
+    if (!checkedAtLeastOne && depth > 0) {
+      logDebug('Stopping GitBook discovery: reached repository root or URL root', { depth });
+      break;
     }
 
     depth += 1;


### PR DESCRIPTION
Description:
This PR fixes [an issue](https://github.com/markdown-viewer/markdown-viewer-extension/issues/80 ) where navigating to a Markdown file on GitHub caused a large number of pointless 404 network requests searching for SUMMARY.md files in directories outside of the active repository's domain scope.

What does this PR do?

**Repository Boundary Enforcement**: Added a new helper that parses the URL and calculates the repository root directory for both github.com and raw.githubusercontent.com.

**Path Traversal Limiting**: During the 20-depth ../ traversal, it now checks summaryParsedUrl.pathname.startsWith(repoRoot). It naturally breaks out of the loop and stops searching once it hits the top of the repository scope, skipping invalid requests.

**Deduplication**: Introduced a visitedUrls Set to track and prevent duplicate fetch attempts for the same resolved SUMMARY.md path.

**Why is it needed?**

Without this limit, the network tab is spammed with up to 40 unneeded 404 requests reaching host roots, hurting performance and raising unnecessary traffic to GitHub's CDNs. This optimization safely limits GitBook discovery to logical project boundaries.

**Testing:**

Open any deeply nested markdown file on raw.githubusercontent.com.
Inspect the Network tab in DevTools.
Verify that SUMMARY.md requests cleanly stop once the parent directory traversal reaches the root of the repository, and no identical URL is checked twice.
