### PR TITLE
feat(remark): fine-grained annotation granularity for tables, lists, and code blocks

### DIFF
--- a/src/ui/remark-mode.ts
+++ b/src/ui/remark-mode.ts
@@ -4,6 +4,7 @@ import type { TranslateFunction } from '../types/core';
 import {
   truncate, formatLineRef, getBlockRange, rangesOverlap, isMediaBlock,
   formatExportText,
+  findTrLineInBlock, findLiLineInBlock, findCodeLineInBlock, narrowLineInBlock,
   COLOR_MAP, COLOR_LABELS, SKIP_ANNOTATION_TAGS,
   type RemarkColor, type RemarkAnnotation,
 } from './remark-utils';
@@ -88,6 +89,7 @@ export function createRemarkMode(options: RemarkModeOptions): RemarkModeControll
 
   let active = false;
   let annotations: RemarkAnnotation[] = [];
+  let softDeletedIds: Set<string> = new Set(); // IDs in 5s undo window — excluded from export
   let abortController: AbortController | null = null;
   let popupEl: HTMLElement | null = null;
   let sidebarEl: HTMLElement | null = null;
@@ -141,11 +143,10 @@ export function createRemarkMode(options: RemarkModeOptions): RemarkModeControll
     renderHighlights();
     showSidebar();
 
-    // Schedule highlight render for when markdown DOM is ready.
-    // Handles: container not yet in DOM, [data-line] not yet rendered, or async re-render.
-    if (!container || !container.querySelector('[data-line]')) {
-      scheduleHighlightsAfterRender();
-    }
+    // Always schedule to catch streamed/async blocks that appear after enter().
+    // Handles: container not yet in DOM, [data-line] not yet rendered, and
+    // incremental streaming renders where only a partial DOM exists at enter() time.
+    scheduleHighlightsAfterRender();
 
     onModeChange?.(true);
   }
@@ -220,13 +221,9 @@ export function createRemarkMode(options: RemarkModeOptions): RemarkModeControll
       renderSidebarContent();
     } else {
       notifyCount();
-      // If URL contains ?remarker=true, auto-enter after DOM is ready
+      // If URL contains ?remarker=true, always auto-enter after DOM is ready
       if (typeof window !== 'undefined' && window.location.search.includes('remarker=true')) {
-        if (annotations.length > 0) {
-          enter();
-        } else {
-          scheduleHighlightsAfterRender();
-        }
+        enter();
       } else if (annotations.length > 0) {
         // Not auto-entering, but schedule highlights so badge renders after DOM is ready
         scheduleHighlightsAfterRender();
@@ -235,41 +232,60 @@ export function createRemarkMode(options: RemarkModeOptions): RemarkModeControll
   }
 
   function scheduleHighlightsAfterRender(): void {
-    function tryOnContainer(): void {
-      const container = getContainer();
-      if (!container) return;
-
+    // Watches for new [data-line] blocks being added to the container (streaming render).
+    // Only reacts to additions of block elements, NOT to highlight spans added by
+    // renderHighlights() itself — preventing infinite loops.
+    // Debounces to coalesce burst renders; self-disconnects after the DOM stabilises.
+    function watchContainer(container: Element): void {
+      // Immediate render if blocks already exist.
       if (container.querySelector('[data-line]')) {
         if (active) { renderHighlights(); renderSidebarContent(); } else { notifyCount(); }
-        return;
       }
 
-      const obs = new MutationObserver(() => {
-        if (container.querySelector('[data-line]')) {
-          obs.disconnect();
-          if (active) {
-            renderHighlights();
-            renderSidebarContent();
-          } else {
-            notifyCount();
-          }
-        }
+      let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+      let stableTimer: ReturnType<typeof setTimeout> | null = null;
+      const DEBOUNCE_MS = 150;
+      const STABLE_MS = 3000;   // disconnect 3 s after the last new block arrives
+      const MAX_MS = 15000;     // hard cap to avoid leaks on very large files
+
+      const obs = new MutationObserver((mutations) => {
+        // Only react when new [data-line] block elements are added, not when
+        // renderHighlights() inserts its own highlight spans (no data-line attr).
+        const hasNewBlock = mutations.some(m =>
+          [...m.addedNodes].some(n =>
+            n instanceof Element &&
+            (n.hasAttribute('data-line') || n.querySelector('[data-line]') !== null)
+          )
+        );
+        if (!hasNewBlock) return;
+
+        if (debounceTimer) clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(() => {
+          if (active) { renderHighlights(); renderSidebarContent(); } else { notifyCount(); }
+        }, DEBOUNCE_MS);
+
+        // Reset the stability timer so we disconnect only after a quiet period.
+        if (stableTimer) clearTimeout(stableTimer);
+        stableTimer = setTimeout(() => obs.disconnect(), STABLE_MS);
       });
+
       obs.observe(container, { childList: true, subtree: true });
+      setTimeout(() => obs.disconnect(), MAX_MS);
     }
 
     const container = getContainer();
     if (container) {
-      tryOnContainer();
+      watchContainer(container);
       return;
     }
 
     // Container not yet in DOM (e.g., ?remarker=true fires before markdown renders).
     // Watch document.body until the container element appears.
     const bodyObs = new MutationObserver(() => {
-      if (getContainer()) {
+      const c = getContainer();
+      if (c) {
         bodyObs.disconnect();
-        tryOnContainer();
+        watchContainer(c);
       }
     });
     bodyObs.observe(document.body, { childList: true, subtree: true });
@@ -311,10 +327,17 @@ export function createRemarkMode(options: RemarkModeOptions): RemarkModeControll
     const startLine = Number(startBlock.getAttribute('data-line')) || 0;
     const startCount = Number(startBlock.getAttribute('data-line-count')) || 1;
 
-    if (!endBlock || endBlock === startBlock) {
+    // Browser Range boundary quirk: when a selection ends exactly at the start of the
+    // next sibling block (offset 0 of the next div.md-block), endContainer lands on that
+    // next block rather than inside the current one.  Treat this as a single-block
+    // selection ending at the end of startBlock.
+    const isBoundaryEnd = endBlock && endBlock !== startBlock && range.endOffset === 0;
+
+    if (!endBlock || endBlock === startBlock || isBoundaryEnd) {
+      const narrow = narrowLineInBlock(range.startContainer, range.startOffset, range.endContainer, range.endOffset, startBlock);
       return {
-        startLine,
-        endLine: startLine + startCount - 1,
+        startLine: narrow?.startLine ?? startLine,
+        endLine: narrow?.endLine ?? (startLine + startCount - 1),
         blockId: startBlock.getAttribute('data-block-id') || undefined,
         startBlock,
       };
@@ -322,13 +345,20 @@ export function createRemarkMode(options: RemarkModeOptions): RemarkModeControll
 
     const endLine = Number(endBlock.getAttribute('data-line')) || 0;
     const endCount = Number(endBlock.getAttribute('data-line-count')) || 1;
+
+    // Cross-block selection: try to narrow each endpoint independently
+    const startNarrow = narrowLineInBlock(range.startContainer, range.startOffset, range.startContainer, range.startOffset, startBlock);
+    const endNarrow = narrowLineInBlock(range.endContainer, range.endOffset, range.endContainer, range.endOffset, endBlock);
     return {
-      startLine,
-      endLine: endLine + endCount - 1,
+      startLine: startNarrow?.startLine ?? startLine,
+      endLine: endNarrow?.endLine ?? (endLine + endCount - 1),
       blockId: startBlock.getAttribute('data-block-id') || undefined,
       startBlock,
     };
   }
+
+
+
 
   function findBlockAncestor(node: Node, container: HTMLElement): HTMLElement | null {
     let el: HTMLElement | null = node instanceof HTMLElement ? node : node.parentElement;
@@ -367,15 +397,16 @@ export function createRemarkMode(options: RemarkModeOptions): RemarkModeControll
   }
 
   function showTooltip(anchor: HTMLElement, anns: RemarkAnnotation[]): void {
+    // Only show tooltip for annotations that have a note written
+    const annsWithNote = anns.filter(a => a.note);
+    if (annsWithNote.length === 0) return;
+
     hideTooltip();
     tooltipEl = document.createElement('div');
     tooltipEl.className = 'remark-tooltip';
 
-    const items = anns.map(a => {
-      const noteText = a.note
-        ? escapeHtml(a.note)
-        : `<em>${escapeHtml(truncate(a.selectedText, 60))}</em>`;
-      return `<div class="remark-tooltip-item">${COLOR_MAP[a.color].emoji} ${noteText}</div>`;
+    const items = annsWithNote.map(a => {
+      return `<div class="remark-tooltip-item">${COLOR_MAP[a.color].emoji} ${escapeHtml(a.note)}</div>`;
     }).join('');
 
     tooltipEl.innerHTML = items;
@@ -447,13 +478,26 @@ export function createRemarkMode(options: RemarkModeOptions): RemarkModeControll
 
     // Wire color buttons — change existing annotation's color
     let interacted = false;
+    const colorsDiv = popupEl.querySelector<HTMLElement>('.remark-popup-colors');
+    const colorToggleBtn = popupEl.querySelector<HTMLButtonElement>('.remark-color-toggle');
     const colorBtns = popupEl.querySelectorAll<HTMLButtonElement>('.remark-color-btn');
+
+    // Toggle color picker on dot click
+    colorToggleBtn?.addEventListener('click', () => {
+      const isOpen = colorsDiv?.style.display !== 'none';
+      if (colorsDiv) colorsDiv.style.display = isOpen ? 'none' : 'flex';
+    });
+
     colorBtns.forEach(btn => {
       btn.addEventListener('click', () => {
         interacted = true;
         colorBtns.forEach(b => b.classList.remove('active'));
         btn.classList.add('active');
         ann.color = btn.dataset.color as RemarkColor;
+        // Update toggle dot to reflect selected color
+        if (colorToggleBtn) colorToggleBtn.textContent = COLOR_MAP[ann.color].emoji;
+        // Collapse the picker after selection
+        if (colorsDiv) colorsDiv.style.display = 'none';
         renderHighlights();
         renderSidebarContent();
         void saveAnnotations();
@@ -520,7 +564,7 @@ export function createRemarkMode(options: RemarkModeOptions): RemarkModeControll
       <div class="remark-popup-header">
         <span class="remark-popup-quote">"${preview}"</span>
       </div>
-      <div class="remark-popup-colors">
+      <div class="remark-popup-colors" style="display:none">
         ${(Object.keys(COLOR_MAP) as RemarkColor[]).map((c, i) => `
           <button class="remark-color-btn${i === 0 ? ' active' : ''}" data-color="${c}" title="${t(`remark_color_${c}`, COLOR_LABELS[c])}">
             ${COLOR_MAP[c].emoji} <span class="remark-color-label">${getColorLabel(c)}</span>
@@ -529,6 +573,7 @@ export function createRemarkMode(options: RemarkModeOptions): RemarkModeControll
       </div>
       <textarea class="remark-note-input" placeholder="${t('remark_add_note', 'Add a note...')}" rows="2"></textarea>
       <div class="remark-popup-actions">
+        <button class="remark-color-toggle" title="${t('remark_change_color', 'Change color')}">${COLOR_MAP.yellow.emoji}</button>
         <button class="remark-cancel-btn">${t('remark_cancel', 'Cancel & remove')}</button>
       </div>
     `;
@@ -571,10 +616,22 @@ export function createRemarkMode(options: RemarkModeOptions): RemarkModeControll
     void saveAnnotations();
   }
 
+  function updateExportBtnState(): void {
+    const exportBtn = sidebarEl?.querySelector<HTMLButtonElement>('.remark-sidebar-export');
+    if (!exportBtn) return;
+    const hasVisible = annotations.some(a => !softDeletedIds.has(a.id));
+    exportBtn.disabled = !hasVisible;
+    exportBtn.style.opacity = hasVisible ? '' : '0.5';
+    exportBtn.style.cursor = hasVisible ? '' : 'not-allowed';
+  }
+
   function removeAnnotation(id: string): void {
     const ann = annotations.find(a => a.id === id);
     if (!ann) return;
     // Soft-delete: hide item and show undo toast with countdown
+    // Immediately exclude from export/copy by tracking in softDeletedIds
+    softDeletedIds.add(id);
+    updateExportBtnState();
     const item = sidebarEl?.querySelector<HTMLElement>(`.remark-sidebar-item[data-ann-id="${id}"]`);
     if (item) {
       item.style.opacity = '0.3';
@@ -604,6 +661,7 @@ export function createRemarkMode(options: RemarkModeOptions): RemarkModeControll
         clearInterval(tick);
         undo.remove();
         annotations = annotations.filter(a => a.id !== id);
+        softDeletedIds.delete(id);
         renderHighlights();
         renderSidebarContent();
         notifyCount();
@@ -614,6 +672,8 @@ export function createRemarkMode(options: RemarkModeOptions): RemarkModeControll
         committed = true;
         clearInterval(tick);
         clearTimeout(timer);
+        softDeletedIds.delete(id);
+        updateExportBtnState();
         undo.remove();
         item.style.opacity = '';
         item.style.pointerEvents = '';
@@ -622,6 +682,7 @@ export function createRemarkMode(options: RemarkModeOptions): RemarkModeControll
     } else {
       // Fallback: immediate delete (sidebar not rendered)
       annotations = annotations.filter(a => a.id !== id);
+      softDeletedIds.delete(id);
       renderHighlights();
       renderSidebarContent();
       notifyCount();
@@ -681,6 +742,9 @@ export function createRemarkMode(options: RemarkModeOptions): RemarkModeControll
         }
       }
     });
+
+    // Set initial copy button disabled state
+    updateExportBtnState();
 
     // Wire clear-all button — immediate clear with 5s undo (consistent with single-item delete)
     const clearBtn = el.querySelector<HTMLButtonElement>('.remark-sidebar-clear');
@@ -805,8 +869,24 @@ export function createRemarkMode(options: RemarkModeOptions): RemarkModeControll
 
       const container = getContainer();
       if (container) {
-        const block = container.querySelector(`[data-line="${ann.startLine}"]`) as HTMLElement | null;
-        if (block) block.scrollIntoView({ behavior: 'auto', block: 'center' });
+        // Use range-overlap so row-level annotations (whose startLine may differ
+        // from the block's data-line) still scroll to the correct block.
+        const block = Array.from(
+          container.querySelectorAll<HTMLElement>('[data-line]')
+        ).find(el => {
+          const { start, end } = getBlockRange(el);
+          return rangesOverlap(start, end, ann.startLine, ann.endLine);
+        }) ?? null;
+        if (block) {
+          const rect = block.getBoundingClientRect();
+          const inViewport = rect.top >= 0 && rect.bottom <= window.innerHeight;
+          if (!inViewport) {
+            block.scrollIntoView({ behavior: 'auto', block: 'center' });
+          } else {
+            block.classList.add('remark-flash');
+            setTimeout(() => block.classList.remove('remark-flash'), 600);
+          }
+        }
       }
 
       const targetItem = list.querySelector(`.remark-sidebar-item[data-ann-id="${id}"]`);
@@ -926,6 +1006,9 @@ export function createRemarkMode(options: RemarkModeOptions): RemarkModeControll
       pendingFocusId = null;
       setTimeout(() => focusAnnotationFromSidebar(focusId), 0);
     }
+
+    // Keep copy button state in sync with visible annotation count
+    updateExportBtnState();
   }
 
   // ─── Highlights ────────────────────────────────────────────────────────────
@@ -944,6 +1027,33 @@ export function createRemarkMode(options: RemarkModeOptions): RemarkModeControll
           block.classList.add('remark-highlighted');
           block.style.setProperty('--remark-bg', COLOR_MAP[ann.color].bg);
           block.style.setProperty('--remark-border', COLOR_MAP[ann.color].border);
+
+          // For narrowed (sub-block) annotations, highlight the specific element
+          const isNarrowed = ann.startLine > blockLine || ann.endLine < blockEnd;
+          if (isNarrowed) {
+            // Table rows
+            const tbody = block.querySelector('tbody');
+            if (tbody) {
+              Array.from(tbody.querySelectorAll<HTMLElement>('tr')).forEach((row, idx) => {
+                const rowLine = blockLine + 2 + idx;
+                if (rangesOverlap(ann.startLine, ann.endLine, rowLine, rowLine)) {
+                  row.classList.add('remark-row-highlighted');
+                  row.dataset.remarkColor = ann.color;
+                }
+              });
+            }
+            // List items
+            const lis = block.querySelectorAll<HTMLElement>('li');
+            if (lis.length > 0) {
+              Array.from(lis).forEach((li, idx) => {
+                const liLine = blockLine + idx;
+                if (rangesOverlap(ann.startLine, ann.endLine, liLine, liLine)) {
+                  li.classList.add('remark-li-highlighted');
+                  li.dataset.remarkColor = ann.color;
+                }
+              });
+            }
+          }
 
           if (!block.querySelector(`.remark-badge[data-ann-id="${ann.id}"]`)) {
             const badge = document.createElement('span');
@@ -973,6 +1083,14 @@ export function createRemarkMode(options: RemarkModeOptions): RemarkModeControll
       (el as HTMLElement).style.removeProperty('--remark-bg');
       (el as HTMLElement).style.removeProperty('--remark-border');
     });
+    container.querySelectorAll('.remark-row-highlighted').forEach(el => {
+      el.classList.remove('remark-row-highlighted');
+      delete (el as HTMLElement).dataset.remarkColor;
+    });
+    container.querySelectorAll('.remark-li-highlighted').forEach(el => {
+      el.classList.remove('remark-li-highlighted');
+      delete (el as HTMLElement).dataset.remarkColor;
+    });
     container.querySelectorAll('.remark-badge').forEach(el => el.remove());
   }
 
@@ -998,7 +1116,7 @@ export function createRemarkMode(options: RemarkModeOptions): RemarkModeControll
       // Keep the best-effort fallback above.
     }
 
-    return formatExportText(annotations, filePath, {
+    return formatExportText(annotations.filter(a => !softDeletedIds.has(a.id)), filePath, {
       intro: tf('remark_export_intro', 'I reviewed **{0}** and have the following feedback:', filePath),
       noteLabel: t('remark_export_note', 'Note'),
       colorLabels: {
@@ -1059,6 +1177,23 @@ export function createRemarkMode(options: RemarkModeOptions): RemarkModeControll
       .remark-mode-active {
         cursor: text;
       }
+      /* Flash animation for blocks already in viewport when sidebar note is clicked */
+      @keyframes remark-flash-anim {
+        0%, 100% { background: var(--remark-bg, rgba(250, 204, 21, 0.15)); }
+        40% { background: rgba(250, 204, 21, 0.5); }
+      }
+      .remark-flash {
+        animation: remark-flash-anim 0.6s ease;
+      }
+      /* Row-level highlight for table annotations with narrowed line ranges */
+      tr.remark-row-highlighted { background: rgba(250, 204, 21, 0.35) !important; }
+      tr.remark-row-highlighted[data-remark-color="green"] { background: rgba(74, 222, 128, 0.35) !important; }
+      tr.remark-row-highlighted[data-remark-color="blue"] { background: rgba(96, 165, 250, 0.35) !important; }
+      tr.remark-row-highlighted[data-remark-color="pink"] { background: rgba(244, 114, 182, 0.35) !important; }
+      li.remark-li-highlighted { background: rgba(250, 204, 21, 0.3) !important; border-radius: 3px; }
+      li.remark-li-highlighted[data-remark-color="green"] { background: rgba(74, 222, 128, 0.3) !important; }
+      li.remark-li-highlighted[data-remark-color="blue"] { background: rgba(96, 165, 250, 0.3) !important; }
+      li.remark-li-highlighted[data-remark-color="pink"] { background: rgba(244, 114, 182, 0.3) !important; }
       .remark-mode-active [data-line][data-block-id]:not(:has(img, svg, canvas, figure, video)):hover {
         outline: 1px dashed var(--color-nav-active-border, var(--color-theme-accent, var(--color-primary, #2563eb)));
         outline-offset: 2px;
@@ -1357,6 +1492,21 @@ export function createRemarkMode(options: RemarkModeOptions): RemarkModeControll
         display: flex;
         justify-content: flex-end;
         gap: 8px;
+        align-items: center;
+      }
+      .remark-color-toggle {
+        font-size: 18px;
+        line-height: 1;
+        padding: 2px 6px;
+        border: 1px solid var(--color-border, #e2e8f0);
+        border-radius: 6px;
+        background: var(--gray-50, #f9fafb);
+        cursor: pointer;
+        margin-right: auto;
+        transition: background 0.15s;
+      }
+      .remark-color-toggle:hover {
+        background: var(--gray-200, #e5e7eb);
       }
       .remark-popup-actions button {
         padding: 6px 14px;

--- a/src/ui/remark-mode.ts
+++ b/src/ui/remark-mode.ts
@@ -157,15 +157,26 @@ export function createRemarkMode(options: RemarkModeOptions): RemarkModeControll
     abortController?.abort();
     abortController = null;
 
+    // Commit any pending deletes immediately on exit
+    if (undoTimer) { clearTimeout(undoTimer); undoTimer = null; }
+    if (undoQueue.length) { commitPendingDeletes(); }
+
     hidePopup();
     hideTooltip();
-    hideSidebar(); // hideSidebar handles removing remark-panel-open after transition
+    onModeChange?.(false); // toolbar state changes immediately
+
+    // Choreographed exit: fade highlights first, then slide sidebar
     const container = getContainer();
     if (container) {
       container.classList.remove('remark-mode-active');
+      container.classList.add('remark-exiting');
+      // Highlights fade via CSS transition (120ms)
+      setTimeout(() => {
+        container.classList.remove('remark-exiting');
+        clearHighlights();
+      }, 160);
     }
-    clearHighlights();
-    onModeChange?.(false);
+    hideSidebar();
   }
 
   // ─── Persistence ─────────────────────────────────────────────────────────
@@ -592,7 +603,8 @@ export function createRemarkMode(options: RemarkModeOptions): RemarkModeControll
   // ─── Annotations ───────────────────────────────────────────────────────────
 
   function notifyCount(): void {
-    onAnnotationCountChange?.(annotations.length);
+    const visibleCount = annotations.filter(a => !softDeletedIds.has(a.id)).length;
+    onAnnotationCountChange?.(visibleCount);
   }
 
   function addAnnotation(
@@ -625,69 +637,82 @@ export function createRemarkMode(options: RemarkModeOptions): RemarkModeControll
     exportBtn.style.cursor = hasVisible ? '' : 'not-allowed';
   }
 
-  function removeAnnotation(id: string): void {
-    const ann = annotations.find(a => a.id === id);
-    if (!ann) return;
-    // Soft-delete: hide item and show undo toast with countdown
-    // Immediately exclude from export/copy by tracking in softDeletedIds
-    softDeletedIds.add(id);
-    updateExportBtnState();
-    const item = sidebarEl?.querySelector<HTMLElement>(`.remark-sidebar-item[data-ann-id="${id}"]`);
-    if (item) {
-      item.style.opacity = '0.3';
-      item.style.pointerEvents = 'none';
-      const UNDO_SECONDS = 5;
-      let remaining = UNDO_SECONDS;
-      // Show inline undo row with countdown and progress bar
-      const undo = document.createElement('div');
-      undo.className = 'remark-undo-row';
-      undo.setAttribute('role', 'status');
-      undo.setAttribute('aria-live', 'polite');
-      undo.innerHTML = `<span>${t('remark_deleted', 'Deleted')}</span><div class="remark-undo-actions"><span class="remark-undo-countdown">${remaining}s</span><button class="remark-undo-btn">↩ ${t('remark_undo', 'Undo')}</button></div><div class="remark-undo-progress" style="animation-duration:${UNDO_SECONDS}s"></div>`;
-      item.after(undo);
-      const countdownEl = undo.querySelector('.remark-undo-countdown')!;
-      let committed = false;
-      const tick = setInterval(() => {
-        remaining--;
-        if (remaining > 0) {
-          countdownEl.textContent = `${remaining}s`;
-        } else {
-          clearInterval(tick);
+  // ─── Undo Toast System ─────────────────────────────────────────────────────
+  // Gmail-style: item disappears immediately, quiet toast with Undo at sidebar bottom.
+  // No countdown, no progress bar, no dimmed corpse.
+
+  let undoQueue: Array<{ id: string; ann: RemarkAnnotation }> = [];
+  let undoTimer: ReturnType<typeof setTimeout> | null = null;
+  const UNDO_MS = 5000;
+
+  function showUndoToast(): void {
+    if (!sidebarEl) return;
+    let toast = sidebarEl.querySelector<HTMLElement>('.remark-undo-toast');
+    if (!toast) {
+      toast = document.createElement('div');
+      toast.className = 'remark-undo-toast';
+      toast.setAttribute('role', 'status');
+      toast.setAttribute('aria-live', 'polite');
+      sidebarEl.appendChild(toast);
+    }
+    const count = undoQueue.length;
+    const label = count > 1
+      ? `${t('remark_deleted', 'Deleted')} ${count}`
+      : t('remark_deleted', 'Deleted');
+    toast.innerHTML = `<span>${label}</span><button class="remark-undo-btn">↩ ${t('remark_undo', 'Undo')}</button>`;
+    toast.style.display = 'flex';
+
+    toast.querySelector('.remark-undo-btn')?.addEventListener('click', () => {
+      if (undoTimer) { clearTimeout(undoTimer); undoTimer = null; }
+      for (const entry of undoQueue) {
+        softDeletedIds.delete(entry.id);
+        // Restore if already removed from array
+        if (!annotations.find(a => a.id === entry.id)) {
+          annotations.push(entry.ann);
         }
-      }, 1000);
-      const commit = () => {
-        if (committed) return;
-        committed = true;
-        clearInterval(tick);
-        undo.remove();
-        annotations = annotations.filter(a => a.id !== id);
-        softDeletedIds.delete(id);
-        renderHighlights();
-        renderSidebarContent();
-        notifyCount();
-        void saveAnnotations();
-      };
-      undo.querySelector('.remark-undo-btn')?.addEventListener('click', () => {
-        if (committed) return;
-        committed = true;
-        clearInterval(tick);
-        clearTimeout(timer);
-        softDeletedIds.delete(id);
-        updateExportBtnState();
-        undo.remove();
-        item.style.opacity = '';
-        item.style.pointerEvents = '';
-      });
-      const timer = setTimeout(commit, UNDO_SECONDS * 1000);
-    } else {
-      // Fallback: immediate delete (sidebar not rendered)
-      annotations = annotations.filter(a => a.id !== id);
-      softDeletedIds.delete(id);
+      }
+      undoQueue = [];
+      hideUndoToast();
       renderHighlights();
       renderSidebarContent();
       notifyCount();
+      updateExportBtnState();
       void saveAnnotations();
+    }, { once: true });
+
+    // Reset the commit timer
+    if (undoTimer) clearTimeout(undoTimer);
+    undoTimer = setTimeout(commitPendingDeletes, UNDO_MS);
+  }
+
+  function hideUndoToast(): void {
+    const toast = sidebarEl?.querySelector<HTMLElement>('.remark-undo-toast');
+    if (toast) toast.style.display = 'none';
+  }
+
+  function commitPendingDeletes(): void {
+    undoTimer = null;
+    for (const entry of undoQueue) {
+      annotations = annotations.filter(a => a.id !== entry.id);
+      softDeletedIds.delete(entry.id);
     }
+    undoQueue = [];
+    hideUndoToast();
+    notifyCount();
+    void saveAnnotations();
+  }
+
+  function removeAnnotation(id: string): void {
+    const ann = annotations.find(a => a.id === id);
+    if (!ann) return;
+    // Optimistic delete: disappear immediately, undo via toast
+    softDeletedIds.add(id);
+    undoQueue.push({ id, ann: { ...ann } });
+    updateExportBtnState();
+    renderHighlights();
+    renderSidebarContent();
+    notifyCount();
+    showUndoToast();
   }
 
   function updateAnnotationNote(id: string, note: string): void {
@@ -746,55 +771,22 @@ export function createRemarkMode(options: RemarkModeOptions): RemarkModeControll
     // Set initial copy button disabled state
     updateExportBtnState();
 
-    // Wire clear-all button — immediate clear with 5s undo (consistent with single-item delete)
+    // Wire clear-all button — uses unified undo toast system
     const clearBtn = el.querySelector<HTMLButtonElement>('.remark-sidebar-clear');
     if (clearBtn) {
       clearBtn.addEventListener('click', () => {
-        if (annotations.length === 0) return;
-        const UNDO_SECONDS = 5;
-        const savedAnnotations = [...annotations];
-        annotations = [];
+        const activeAnns = annotations.filter(a => !softDeletedIds.has(a.id));
+        if (activeAnns.length === 0) return;
+        // Queue all active annotations for undo
+        for (const ann of activeAnns) {
+          softDeletedIds.add(ann.id);
+          undoQueue.push({ id: ann.id, ann: { ...ann } });
+        }
+        updateExportBtnState();
         renderHighlights();
         renderSidebarContent();
         notifyCount();
-        void saveAnnotations();
-
-        const list = el.querySelector<HTMLElement>('.remark-sidebar-list');
-        if (!list) return;
-        let remaining = UNDO_SECONDS;
-        const undo = document.createElement('div');
-        undo.className = 'remark-undo-row';
-        undo.setAttribute('role', 'status');
-        undo.setAttribute('aria-live', 'polite');
-        undo.innerHTML = `<span>${t('remark_all_cleared', 'All cleared')}</span><div class="remark-undo-actions"><span class="remark-undo-countdown">${remaining}s</span><button class="remark-undo-btn">↩ ${t('remark_undo', 'Undo')}</button></div><div class="remark-undo-progress" style="animation-duration:${UNDO_SECONDS}s"></div>`;
-        list.prepend(undo);
-
-        const countdownEl = undo.querySelector<HTMLElement>('.remark-undo-countdown')!;
-        let committed = false;
-        const tick = setInterval(() => {
-          remaining--;
-          if (remaining > 0) countdownEl.textContent = `${remaining}s`;
-          else clearInterval(tick);
-        }, 1000);
-        const commit = (): void => {
-          if (committed) return;
-          committed = true;
-          clearInterval(tick);
-          undo.remove();
-        };
-        undo.querySelector('.remark-undo-btn')?.addEventListener('click', () => {
-          if (committed) return;
-          committed = true;
-          clearInterval(tick);
-          clearTimeout(timer);
-          undo.remove();
-          annotations = savedAnnotations;
-          renderHighlights();
-          renderSidebarContent();
-          notifyCount();
-          void saveAnnotations();
-        });
-        const timer = setTimeout(commit, UNDO_SECONDS * 1000);
+        showUndoToast();
       });
     }
 
@@ -804,7 +796,7 @@ export function createRemarkMode(options: RemarkModeOptions): RemarkModeControll
   function hideSidebar(): void {
     if (sidebarEl) {
       sidebarEl.classList.add('remark-sidebar-closed');
-      // Remove margin immediately so it transitions simultaneously with the sidebar slide-out
+      // Body margin transitions via CSS (same duration as sidebar slide-out)
       document.body.classList.remove('remark-panel-open');
       const el = sidebarEl;
       sidebarEl = null;
@@ -833,17 +825,20 @@ export function createRemarkMode(options: RemarkModeOptions): RemarkModeControll
     const countEl = sidebarEl.querySelector('.remark-sidebar-count');
     if (!list) return;
 
+    // Filter out soft-deleted annotations
+    const visibleAnnotations = annotations.filter(a => !softDeletedIds.has(a.id));
+
     // Update count badge in header
     if (countEl) {
-      countEl.textContent = annotations.length > 0 ? `(${annotations.length})` : '';
+      countEl.textContent = visibleAnnotations.length > 0 ? `(${visibleAnnotations.length})` : '';
     }
 
-    if (annotations.length === 0) {
+    if (visibleAnnotations.length === 0) {
       list.innerHTML = `<div class="remark-sidebar-empty">${t('remark_empty_hint', 'Select text to add remarks')}</div>`;
       return;
     }
 
-    const sorted = [...annotations].sort((a, b) => a.startLine - b.startLine);
+    const sorted = [...visibleAnnotations].sort((a, b) => a.startLine - b.startLine);
     list.innerHTML = sorted.map(ann => {
       const lineRef = formatLineRef(ann.startLine, ann.endLine);
       const quote = escapeHtml(truncate(ann.selectedText, 50));
@@ -882,9 +877,15 @@ export function createRemarkMode(options: RemarkModeOptions): RemarkModeControll
           const inViewport = rect.top >= 0 && rect.bottom <= window.innerHeight;
           if (!inViewport) {
             block.scrollIntoView({ behavior: 'auto', block: 'center' });
+            // Landing pulse after scroll settles
+            setTimeout(() => {
+              block.classList.add('remark-landing');
+              setTimeout(() => block.classList.remove('remark-landing'), 1000);
+            }, 300);
           } else {
-            block.classList.add('remark-flash');
-            setTimeout(() => block.classList.remove('remark-flash'), 600);
+            // Already visible — pulse immediately
+            block.classList.add('remark-landing');
+            setTimeout(() => block.classList.remove('remark-landing'), 1000);
           }
         }
       }
@@ -1018,7 +1019,10 @@ export function createRemarkMode(options: RemarkModeOptions): RemarkModeControll
     const container = getContainer();
     if (!container) return;
 
-    for (const ann of annotations) {
+    // Only render active (non-deleted) annotations
+    const visibleAnnotations = annotations.filter(a => !softDeletedIds.has(a.id));
+
+    for (const ann of visibleAnnotations) {
       const blocks = container.querySelectorAll<HTMLElement>('[data-line]');
       for (const block of blocks) {
         const { start: blockLine, end: blockEnd } = getBlockRange(block);
@@ -1177,13 +1181,22 @@ export function createRemarkMode(options: RemarkModeOptions): RemarkModeControll
       .remark-mode-active {
         cursor: text;
       }
-      /* Flash animation for blocks already in viewport when sidebar note is clicked */
-      @keyframes remark-flash-anim {
-        0%, 100% { background: var(--remark-bg, rgba(250, 204, 21, 0.15)); }
-        40% { background: rgba(250, 204, 21, 0.5); }
+      /* Choreographed exit: fade highlights before removing them */
+      .remark-exiting .remark-highlighted,
+      .remark-exiting .remark-badge,
+      .remark-exiting .remark-row-highlighted,
+      .remark-exiting .remark-li-highlighted {
+        opacity: 0;
+        transition: opacity 120ms ease-out;
       }
-      .remark-flash {
-        animation: remark-flash-anim 0.6s ease;
+      /* Landing pulse — stronger ring+glow for sidebar navigation */
+      @keyframes remark-landing-anim {
+        0%   { box-shadow: 0 0 0 3px rgba(250, 204, 21, 0.6); background-color: rgba(250, 204, 21, 0.25); }
+        100% { box-shadow: 0 0 0 0 transparent; background-color: transparent; }
+      }
+      .remark-landing {
+        animation: remark-landing-anim 1s ease-out;
+        border-radius: 3px;
       }
       /* Row-level highlight for table annotations with narrowed line ranges */
       tr.remark-row-highlighted { background: rgba(250, 204, 21, 0.35) !important; }
@@ -1360,42 +1373,29 @@ export function createRemarkMode(options: RemarkModeOptions): RemarkModeControll
         color: var(--color-danger, #ef4444);
         background: var(--color-danger-bg, rgba(239, 68, 68, 0.1));
       }
-      /* Undo row after soft-deleted item */
-      .remark-undo-row {
-        display: flex;
+      /* Undo toast — fixed at bottom of sidebar */
+      .remark-undo-toast {
+        display: none;
         align-items: center;
         justify-content: space-between;
-        padding: 4px 8px;
-        margin-bottom: 8px;
-        border-radius: 6px;
+        padding: 8px 12px;
+        border-top: 1px solid var(--color-border, #e2e8f0);
         background: var(--gray-100, #f3f4f6);
         font-size: 12px;
-        color: var(--gray-500, #6b7280);
-        position: relative;
-        overflow: hidden;
+        color: var(--gray-600, #4b5563);
+        flex-shrink: 0;
       }
-      .remark-undo-btn {
+      .remark-undo-toast .remark-undo-btn {
         border: 1px solid var(--color-border, #e2e8f0);
         border-radius: 4px;
         background: var(--color-bg-surface, #fff);
         cursor: pointer;
         font-size: 11px;
-        padding: 2px 8px;
+        padding: 3px 10px;
         color: var(--color-theme-accent, var(--color-primary, #2563eb));
+        transition: background 0.1s;
       }
-      .remark-undo-btn:hover { background: var(--gray-50, #f9fafb); }
-      .remark-undo-actions {
-        display: flex;
-        align-items: center;
-        gap: 6px;
-      }
-      .remark-undo-countdown {
-        font-size: 10px;
-        color: var(--gray-400, #9ca3af);
-        font-variant-numeric: tabular-nums;
-        min-width: 18px;
-        text-align: right;
-      }
+      .remark-undo-toast .remark-undo-btn:hover { background: var(--gray-50, #f9fafb); }
       .remark-sidebar-quote {
         font-style: italic;
         color: var(--gray-500, #6b7280);
@@ -1607,27 +1607,6 @@ export function createRemarkMode(options: RemarkModeOptions): RemarkModeControll
           70% { box-shadow: 0 0 0 6px transparent; }
           100% { box-shadow: none; }
         }
-
-        /* Undo progress bar shrink */
-        .remark-undo-progress {
-          animation: remark-shrink linear forwards;
-        }
-        @keyframes remark-shrink {
-          from { width: 100%; }
-          to { width: 0%; }
-        }
-      }
-
-      /* Undo progress bar base style */
-      .remark-undo-progress {
-        position: absolute;
-        bottom: 0;
-        left: 0;
-        height: 2px;
-        width: 100%;
-        background: var(--color-theme-accent, var(--color-primary, #2563eb));
-        opacity: 0.4;
-        pointer-events: none;
       }
 
       /* Color button labels */

--- a/src/ui/remark-utils.ts
+++ b/src/ui/remark-utils.ts
@@ -93,6 +93,121 @@ export function rangesOverlap(aStart: number, aEnd: number, bStart: number, bEnd
   return aStart <= bEnd && aEnd >= bStart;
 }
 
+// ─── Sub-block line narrowing helpers ───────────────────────────────────────
+// Exported here (not in remark-mode.ts) so unit tests can import without DOM globals.
+
+const TEXT_NODE = 3; // Node.TEXT_NODE constant
+
+function toElement(node: Node): Element | null {
+  return ('tagName' in node) ? (node as unknown as Element) : (node as Node).parentElement;
+}
+
+/**
+ * Table row → exact markdown line.
+ * header row = blockStart, separator = blockStart+1, tbody[i] = blockStart+2+i
+ */
+export function findTrLineInBlock(node: Node, blockEl: Element): number | null {
+  let el: Element | null = toElement(node);
+  const blockStart = Number(blockEl.getAttribute('data-line')) || 0;
+  while (el && el !== blockEl) {
+    if ((el as Element).tagName === 'TR') {
+      const section = el.parentElement;
+      if (!section) return null;
+      if (section.tagName === 'THEAD') return blockStart;
+      if (section.tagName === 'TBODY') {
+        const rowIdx = Array.from(section.children).indexOf(el as HTMLElement);
+        return rowIdx >= 0 ? blockStart + 2 + rowIdx : null;
+      }
+      return null;
+    }
+    el = el.parentElement;
+  }
+  return null;
+}
+
+/**
+ * List item → approximate markdown line.
+ * Uses document-order <li> index within the block as the line offset.
+ * Works for flat and nested lists; may be off by ≤1 for multi-line items.
+ */
+export function findLiLineInBlock(node: Node, blockEl: Element): number | null {
+  let el: Element | null = toElement(node);
+  const blockStart = Number(blockEl.getAttribute('data-line')) || 0;
+  while (el && el !== blockEl) {
+    if (el.tagName === 'LI') {
+      const allLis = Array.from(blockEl.querySelectorAll('li'));
+      const idx = allLis.indexOf(el as HTMLElement);
+      return idx >= 0 ? blockStart + idx : null;
+    }
+    el = el.parentElement;
+  }
+  return null;
+}
+
+/**
+ * Code block → approximate markdown line.
+ * Walks text nodes inside <pre> counting newlines before the selection point.
+ * blockStart = opening fence line; code body starts at blockStart+1.
+ */
+export function findCodeLineInBlock(node: Node, offset: number, blockEl: Element): number | null {
+  const pre = (blockEl.tagName === 'PRE' ? blockEl : blockEl.querySelector('pre')) as Node | null;
+  if (!pre) return null;
+  const blockStart = Number(blockEl.getAttribute('data-line')) || 0;
+
+  let newlines = 0;
+  let found = false;
+
+  const walk = (n: Node): void => {
+    if (found) return;
+    if (n === node) {
+      newlines += ((n.textContent || '').slice(0, offset).match(/\n/g) || []).length;
+      found = true;
+      return;
+    }
+    if (n.nodeType === TEXT_NODE) {
+      newlines += (n.textContent || '').split('\n').length - 1;
+    }
+    for (const child of n.childNodes) {
+      if (found) break;
+      walk(child);
+    }
+  };
+  walk(pre);
+  // blockStart = ``` fence line; first code line = blockStart+1
+  return found ? blockStart + 1 + newlines : null;
+}
+
+/**
+ * Try to narrow a selection within a block to a specific line range.
+ * Tries table rows → list items → code lines, in that order.
+ * Returns null when the block type has no useful sub-structure.
+ */
+export function narrowLineInBlock(
+  startNode: Node, startOffset: number,
+  endNode: Node, endOffset: number,
+  blockEl: Element,
+): { startLine: number; endLine: number } | null {
+  // 1. Table row (exact)
+  const startTr = findTrLineInBlock(startNode, blockEl);
+  if (startTr !== null) {
+    const endTr = findTrLineInBlock(endNode, blockEl);
+    return { startLine: startTr, endLine: endTr ?? startTr };
+  }
+  // 2. List item (approximate — LI document order within block)
+  const startLi = findLiLineInBlock(startNode, blockEl);
+  if (startLi !== null) {
+    const endLi = findLiLineInBlock(endNode, blockEl);
+    return { startLine: startLi, endLine: endLi ?? startLi };
+  }
+  // 3. Code block (approximate — newline count in pre/code text)
+  const startCode = findCodeLineInBlock(startNode, startOffset, blockEl);
+  if (startCode !== null) {
+    const endCode = findCodeLineInBlock(endNode, endOffset, blockEl);
+    return { startLine: startCode, endLine: endCode ?? startCode };
+  }
+  return null;
+}
+
 /** Check if a block element is a media/image block that should not be annotatable. */
 export function isMediaBlock(el: HTMLElement): boolean {
   if (SKIP_ANNOTATION_TAGS.has(el.tagName)) return true;

--- a/test/remark-mode.test.ts
+++ b/test/remark-mode.test.ts
@@ -15,6 +15,10 @@ import {
   getBlockRange,
   isMediaBlock,
   formatExportText,
+  findTrLineInBlock,
+  findLiLineInBlock,
+  findCodeLineInBlock,
+  narrowLineInBlock,
 } from '../src/ui/remark-utils.ts';
 
 // ─── truncate ────────────────────────────────────────────────────────────────
@@ -300,5 +304,377 @@ describe('formatExportText', () => {
     assert.ok(result.startsWith('He revisado **/tmp/test.md** y tengo los siguientes comentarios:'));
     assert.ok(result.includes('[🔵 Pregunta] L5:'));
     assert.ok(result.includes('Nota: "ajusta esto"'));
+  });
+});
+
+// ─── DOM stub helpers ─────────────────────────────────────────────────────────
+// Lightweight object trees that satisfy the interfaces used by the three
+// sub-block narrowing helpers, without requiring jsdom or a browser.
+
+type StubNode = {
+  nodeType?: number; // 3 = TEXT_NODE
+  textContent?: string | null;
+  tagName?: string;
+  parentElement?: StubNode | null;
+  children?: StubNode[];
+  childNodes?: StubNode[];
+  getAttribute?: (name: string) => string | null;
+  querySelectorAll?: (sel: string) => StubNode[];
+  querySelector?: (sel: string) => StubNode | null;
+};
+
+/** Build a minimal block element stub (has data-line + querySelectorAll). */
+function makeBlock(attrs: Record<string, string>, overrides: Partial<StubNode> = {}): StubNode {
+  return {
+    tagName: attrs._tagName ?? 'DIV',
+    getAttribute(name: string) { return attrs[name] ?? null; },
+    querySelectorAll(_sel: string) { return []; },
+    querySelector(_sel: string) { return null; },
+    ...overrides,
+  };
+}
+
+/** Link a chain of parent elements: [child, parent, grandparent, ...] */
+function linkParents(chain: StubNode[]): void {
+  for (let i = 0; i < chain.length - 1; i++) {
+    chain[i].parentElement = chain[i + 1] as unknown as StubNode;
+  }
+  chain[chain.length - 1].parentElement = null;
+}
+
+// ─── findTrLineInBlock ────────────────────────────────────────────────────────
+// Markdown table layout (blockStart = 10):
+//   L10  | Col A | Col B |   ← THEAD row
+//   L11  |-------|-------|   ← separator (not in DOM)
+//   L12  | r0c0  | r0c1  |   ← TBODY tr[0]
+//   L13  | r1c0  | r1c1  |   ← TBODY tr[1]
+
+describe('findTrLineInBlock', () => {
+  it('node inside THEAD TR → blockStart', () => {
+    // DOM: block > THEAD > TR > TD  (user selected text in the header cell)
+    // Expected: L10 (header row maps to blockStart)
+    const block = makeBlock({ 'data-line': '10' });
+    const thead = { tagName: 'THEAD', parentElement: block, children: [] } as StubNode;
+    const tr = { tagName: 'TR', parentElement: thead } as StubNode;
+    thead.children = [tr];
+    const td = { tagName: 'TD', parentElement: tr } as StubNode;
+
+    assert.strictEqual(findTrLineInBlock(td as unknown as Node, block as unknown as Element), 10);
+  });
+
+  it('node inside TBODY TR[0] → blockStart+2', () => {
+    // DOM: block > TBODY > TR[0] > TD  (user selected text in first data row)
+    // Expected: L12 = blockStart(10) + 2 (header + separator skip)
+    const block = makeBlock({ 'data-line': '10' });
+    const tbody = { tagName: 'TBODY', parentElement: block, children: [] } as StubNode;
+    const tr0 = { tagName: 'TR', parentElement: tbody } as StubNode;
+    const tr1 = { tagName: 'TR', parentElement: tbody } as StubNode;
+    tbody.children = [tr0, tr1];
+    const td = { tagName: 'TD', parentElement: tr0 } as StubNode;
+
+    assert.strictEqual(findTrLineInBlock(td as unknown as Node, block as unknown as Element), 12);
+  });
+
+  it('node inside TBODY TR[1] → blockStart+3', () => {
+    // DOM: block > TBODY > TR[1] > SPAN  (user selected content in second data row)
+    // Expected: L13 = blockStart(10) + 2 + rowIndex(1)
+    const block = makeBlock({ 'data-line': '10' });
+    const tbody = { tagName: 'TBODY', parentElement: block, children: [] } as StubNode;
+    const tr0 = { tagName: 'TR', parentElement: tbody } as StubNode;
+    const tr1 = { tagName: 'TR', parentElement: tbody } as StubNode;
+    tbody.children = [tr0, tr1];
+    const span = { tagName: 'SPAN', parentElement: tr1 } as StubNode;
+
+    assert.strictEqual(findTrLineInBlock(span as unknown as Node, block as unknown as Element), 13);
+  });
+
+  it('node not inside TR → null', () => {
+    // DOM: block > P > SPAN  (paragraph block, no table structure)
+    // Expected: null — not a table, no narrowing possible
+    const block = makeBlock({ 'data-line': '10' });
+    const p = { tagName: 'P', parentElement: block } as StubNode;
+    const text = { tagName: 'SPAN', parentElement: p } as StubNode;
+
+    assert.strictEqual(findTrLineInBlock(text as unknown as Node, block as unknown as Element), null);
+  });
+
+  it('node is a text node (no tagName) → walks parentElement', () => {
+    // DOM: block > THEAD > TR > TD > textNode
+    // Browser selections often land on raw text nodes, not elements.
+    // The function must start from parentElement when node has no tagName.
+    // Expected: L5 (header row of block starting at L5)
+    const block = makeBlock({ 'data-line': '5' });
+    const thead = { tagName: 'THEAD', parentElement: block, children: [] } as StubNode;
+    const tr = { tagName: 'TR', parentElement: thead } as StubNode;
+    thead.children = [tr];
+    const td = { tagName: 'TD', parentElement: tr } as StubNode;
+    const textNode = { nodeType: 3, textContent: 'hello', parentElement: td } as StubNode;
+
+    assert.strictEqual(findTrLineInBlock(textNode as unknown as Node, block as unknown as Element), 5);
+  });
+});
+
+// ─── findLiLineInBlock ────────────────────────────────────────────────────────
+// Markdown list layout (blockStart = 20):
+//   L20  - item 0
+//   L21  - item 1
+//   L22  - item 2
+//
+// For nested lists the entire nested subtree is one block;
+// querySelectorAll('li') returns items in document order:
+//   L30  - outer item 0
+//   L31  - outer item 1
+//   L32      - nested item 0  (child of item 1)
+
+describe('findLiLineInBlock', () => {
+  function makeListBlock(liCount: number, dataLine = '20'): { block: StubNode; lis: StubNode[] } {
+    const lis: StubNode[] = Array.from({ length: liCount }, () => ({
+      tagName: 'LI',
+      parentElement: null as unknown as StubNode,
+    }));
+    const ul = { tagName: 'UL', parentElement: null as unknown as StubNode, children: lis } as StubNode;
+    const block = makeBlock({ 'data-line': dataLine }, {
+      querySelectorAll(_sel: string) { return lis; },
+    });
+    ul.parentElement = block;
+    lis.forEach(li => (li.parentElement = ul));
+    block.children = [ul];
+    return { block, lis };
+  }
+
+  it('node inside first LI → blockStart+0', () => {
+    // Markdown: L20 "- item 0"  ← user selected text inside a <span> in LI[0]
+    // Expected: L20 (index 0, no offset)
+    const { block, lis } = makeListBlock(3);
+    const span = { tagName: 'SPAN', parentElement: lis[0] } as StubNode;
+
+    assert.strictEqual(findLiLineInBlock(span as unknown as Node, block as unknown as Element), 20);
+  });
+
+  it('node inside third LI → blockStart+2', () => {
+    // Markdown: L22 "- item 2"  ← user selected text inside LI[2]
+    // Expected: L22 = blockStart(20) + index(2)
+    const { block, lis } = makeListBlock(3);
+    const span = { tagName: 'SPAN', parentElement: lis[2] } as StubNode;
+
+    assert.strictEqual(findLiLineInBlock(span as unknown as Node, block as unknown as Element), 22);
+  });
+
+  it('node not inside any LI → null', () => {
+    // DOM: block > P  (not a list block — e.g., a paragraph)
+    // Expected: null — no LI ancestor found, narrowing not applicable
+    const block = makeBlock({ 'data-line': '20' });
+    const p = { tagName: 'P', parentElement: block } as StubNode;
+
+    assert.strictEqual(findLiLineInBlock(p as unknown as Node, block as unknown as Element), null);
+  });
+
+  it('nested LI: uses the innermost LI document order', () => {
+    // Markdown (blockStart = 30):
+    //   L30  - outer item 0        ← li0
+    //   L31  - outer item 1        ← li1
+    //   L32      - nested item 0   ← li2 (child of li1)
+    //
+    // querySelectorAll('li') returns [li0, li1, li2] in document order.
+    // User selects text inside li2 (the nested item).
+    // Expected: L32 = blockStart(30) + index(2)
+    const li0 = { tagName: 'LI' } as StubNode;
+    const li1 = { tagName: 'LI' } as StubNode;
+    const li2 = { tagName: 'LI' } as StubNode;
+    const ul_nested = { tagName: 'UL', parentElement: li1 } as StubNode;
+    li2.parentElement = ul_nested;
+    const ul_outer = { tagName: 'UL' } as StubNode;
+    li0.parentElement = ul_outer;
+    li1.parentElement = ul_outer;
+    const block = makeBlock({ 'data-line': '30' }, {
+      querySelectorAll(_sel: string) { return [li0, li1, li2]; },
+    });
+    ul_outer.parentElement = block;
+    ul_nested.parentElement = li1;
+    const span = { tagName: 'SPAN', parentElement: li2 } as StubNode;
+
+    assert.strictEqual(findLiLineInBlock(span as unknown as Node, block as unknown as Element), 32);
+  });
+});
+
+// ─── findCodeLineInBlock ──────────────────────────────────────────────────────
+// Markdown code block layout (blockStart = 40):
+//   L40  ```typescript          ← opening fence (not in rendered DOM text)
+//   L41  const x = 1;           ← first code line → blockStart+1
+//   L42  const y = 2;           ← second code line → blockStart+2
+//   L43  return x + y;          ← third code line → blockStart+3
+//   L44  ```                    ← closing fence
+//
+// The <pre> element contains text nodes produced by the syntax highlighter.
+// The function counts '\n' characters in text nodes before the selection point.
+
+describe('findCodeLineInBlock', () => {
+  /** Build a text node stub with no children (leaf). */
+  function makeText(text: string, parent?: StubNode): StubNode {
+    const n: StubNode = {
+      nodeType: 3,
+      textContent: text,
+      childNodes: [],
+      parentElement: parent ?? null,
+    };
+    return n;
+  }
+
+  /**
+   * Build a PRE block whose childNodes are flat text node stubs.
+   * Simulates a syntax-highlighted code block where the highlighter has
+   * wrapped tokens in spans but we flatten to text nodes for simplicity.
+   */
+  function makePre(texts: string[], dataLine = '40'): { block: StubNode; textNodes: StubNode[]; pre: StubNode } {
+    const textNodes = texts.map(t => makeText(t));
+    const pre: StubNode = {
+      tagName: 'PRE',
+      nodeType: 1,
+      textContent: texts.join(''),
+      childNodes: textNodes,
+    };
+    textNodes.forEach(t => (t.parentElement = pre));
+    const block = makeBlock({ 'data-line': dataLine, _tagName: 'PRE' });
+    // The block itself IS the <pre> element in this simplified setup
+    Object.assign(block, { childNodes: textNodes });
+    return { block, textNodes, pre };
+  }
+
+  it('block has no <pre> and is not PRE → null', () => {
+    // A DIV block (not a code block) with no querySelector('pre') match.
+    // findCodeLineInBlock must bail out immediately and return null.
+    const block = makeBlock({ 'data-line': '40' }); // tagName defaults to DIV
+    const txt = makeText('hello');
+
+    assert.strictEqual(findCodeLineInBlock(txt as unknown as Node, 0, block as unknown as Element), null);
+  });
+
+  it('node is first text node, offset 0 → blockStart+1', () => {
+    // PRE text nodes: ["first line\n", "second line"]
+    // Selection: start of textNodes[0], offset 0 (cursor before any char).
+    // Newlines counted before target = 0 → line = blockStart+1+0 = 41
+    const { block, textNodes } = makePre(['first line\n', 'second line']);
+    const target = textNodes[0];
+
+    assert.strictEqual(findCodeLineInBlock(target as unknown as Node, 0, block as unknown as Element), 41);
+  });
+
+  it('node is first text node, offset after 1 newline → blockStart+2', () => {
+    // PRE text: "line1\nline2\n" (single text node)
+    // Selection: offset 6 = just after the first '\n' (i.e., cursor at start of "line2").
+    // textContent.slice(0, 6) = "line1\n" → 1 newline counted in target node.
+    // Total newlines before cursor = 1 → line = blockStart+1+1 = 42
+    const { block, textNodes } = makePre(['line1\nline2\n', 'line3']);
+    const target = textNodes[0];
+    assert.strictEqual(findCodeLineInBlock(target as unknown as Node, 6, block as unknown as Element), 42);
+  });
+
+  it('node is second text node → counts newlines in first + offset', () => {
+    // PRE text nodes: ["line1\nline2\n", "line3\n"]
+    // textNodes[0] has 2 '\n' → those are counted as the walker passes through it.
+    // Selection: start of textNodes[1], offset 0.
+    // Total newlines before cursor = 2 → line = blockStart+1+2 = 43
+    const { block, textNodes } = makePre(['line1\nline2\n', 'line3\n']);
+    const target = textNodes[1];
+    assert.strictEqual(findCodeLineInBlock(target as unknown as Node, 0, block as unknown as Element), 43);
+  });
+
+  it('node not found in tree → null', () => {
+    // A text node that is not part of the PRE subtree at all.
+    // The walk exhausts all nodes without finding the target → returns null.
+    const { block } = makePre(['hello\nworld']);
+    const stranger = makeText('stranger');
+
+    assert.strictEqual(findCodeLineInBlock(stranger as unknown as Node, 0, block as unknown as Element), null);
+  });
+});
+
+// ─── narrowLineInBlock ────────────────────────────────────────────────────────
+// This is the top-level dispatcher. It tries table → list → code in order
+// and returns the first successful narrowing, or null for plain blocks.
+
+describe('narrowLineInBlock', () => {
+  it('table block: returns TR line for both endpoints', () => {
+    // User drags selection across two rows (TR[0] and TR[1]) in a table block at L10.
+    // DOM: block > TBODY > [TR[0] > TD (start), TR[1] > TD (end)]
+    // Expected: { startLine: 12, endLine: 13 }  (blockStart+2 and blockStart+3)
+    const block = makeBlock({ 'data-line': '10' });
+    const tbody = { tagName: 'TBODY', parentElement: block, children: [] } as StubNode;
+    const tr0 = { tagName: 'TR', parentElement: tbody } as StubNode;
+    const tr1 = { tagName: 'TR', parentElement: tbody } as StubNode;
+    tbody.children = [tr0, tr1];
+    const startNode = { tagName: 'TD', parentElement: tr0 } as StubNode;
+    const endNode = { tagName: 'TD', parentElement: tr1 } as StubNode;
+
+    const result = narrowLineInBlock(startNode as unknown as Node, 0, endNode as unknown as Node, 0, block as unknown as Element);
+    assert.deepStrictEqual(result, { startLine: 12, endLine: 13 });
+  });
+
+  it('list block: returns LI lines for both endpoints', () => {
+    // User drags selection from LI[0] to LI[1] in a list block at L20.
+    // querySelectorAll('li') → [li0, li2] (document order, 2 items)
+    // startNode is inside li0 (index 0) → L20; endNode is inside li2 (index 1) → L21
+    // Expected: { startLine: 20, endLine: 21 }
+    const li0 = { tagName: 'LI' } as StubNode;
+    const li2 = { tagName: 'LI' } as StubNode;
+    const ul = { tagName: 'UL' } as StubNode;
+    li0.parentElement = ul;
+    li2.parentElement = ul;
+    const block = makeBlock({ 'data-line': '20' }, {
+      querySelectorAll(_sel: string) { return [li0, li2]; },
+    });
+    ul.parentElement = block;
+    const startNode = { tagName: 'SPAN', parentElement: li0 } as StubNode;
+    const endNode = { tagName: 'SPAN', parentElement: li2 } as StubNode;
+
+    const result = narrowLineInBlock(startNode as unknown as Node, 0, endNode as unknown as Node, 0, block as unknown as Element);
+    assert.deepStrictEqual(result, { startLine: 20, endLine: 21 });
+  });
+
+  it('plain paragraph block → null', () => {
+    // A <p> block — no table/list/code sub-structure exists.
+    // All three strategies (TR, LI, code) return null.
+    // Expected: null (caller falls back to full block range)
+    const block = makeBlock({ 'data-line': '5' });
+    const p = { tagName: 'P', parentElement: block } as StubNode;
+
+    const result = narrowLineInBlock(p as unknown as Node, 0, p as unknown as Node, 0, block as unknown as Element);
+    assert.strictEqual(result, null);
+  });
+
+  it('table block: same row → startLine === endLine', () => {
+    // User selects text within a single table cell (start and end both in TR[0]).
+    // Both endpoints resolve to the same row → startLine and endLine must be equal.
+    // Expected: { startLine: 12, endLine: 12 }
+    const block = makeBlock({ 'data-line': '10' });
+    const tbody = { tagName: 'TBODY', parentElement: block, children: [] } as StubNode;
+    const tr0 = { tagName: 'TR', parentElement: tbody } as StubNode;
+    tbody.children = [tr0];
+    const node = { tagName: 'TD', parentElement: tr0 } as StubNode;
+
+    const result = narrowLineInBlock(node as unknown as Node, 0, node as unknown as Node, 0, block as unknown as Element);
+    assert.deepStrictEqual(result, { startLine: 12, endLine: 12 });
+  });
+
+  it('heading block → null (caller uses full 1-line block range)', () => {
+    // Heading blocks (## H2, # H1, etc.) are always single-line in the block
+    // splitter.  narrowLineInBlock has no heading strategy and must return null,
+    // so the caller falls back to { startLine: blockLine, endLine: blockLine }
+    // (lineCount = 1 → startLine + 1 - 1 = startLine).
+    //
+    // Real-world scenario (the regression case):
+    //   file line 35 (0-indexed L34): "## 发现 2：会议/沟通仅 4%——Manager 去哪了？"
+    //   Block: data-line=34, data-line-count=1
+    //   Expected annotation: L34 (single line), NOT L34-L36.
+    //
+    // DOM: block[data-line=34] > H2 > textNode
+    //   The block has lineCount=1, so caller computes endLine = 34+1-1 = 34.
+    const block = makeBlock({ 'data-line': '34', 'data-line-count': '1' });
+    const h2 = { tagName: 'H2', parentElement: block } as StubNode;
+    const textNode = { nodeType: 3, textContent: '发现 2：会议/沟通仅 4%', parentElement: h2 } as StubNode;
+
+    const result = narrowLineInBlock(textNode as unknown as Node, 0, textNode as unknown as Node, 0, block as unknown as Element);
+    assert.strictEqual(result, null);
+    // Caller uses: startLine + lineCount - 1 = 34 + 1 - 1 = 34 (L34 only, not L34-L36)
   });
 });


### PR DESCRIPTION
## Problem

When annotating long blocks in Remark Mode, the line reference spans the entire block — e.g., selecting one cell in a 10-row table produces `L28–L37`. This makes the exported feedback hard for AI agents (and humans) to locate precisely.

## Solution

Narrows the annotation line reference to the specific sub-element selected:

| Block type | Granularity | Accuracy |
|---|---|---|
| **Table rows** | Per-row (exact) | Header = `blockStart`, tbody[i] = `blockStart+2+i` |
| **List items** | Per-item (approx) | Document-order `<li>` index within block (off by ≤1 for multi-line items) |
| **Code blocks** | Per-line (approx) | Newline count via text-node walk + 1 for fence line |

Visual feedback: selected table rows and list items also receive a colored highlight (4 color variants each).

## Architecture

Extracted `findTrLineInBlock`, `findLiLineInBlock`, `findCodeLineInBlock`, and `narrowLineInBlock` from the `initRemarkMode` closure into `remark-utils.ts`:
- **Pure / testable** — no DOM globals, duck-typed node stubs
- **Single dispatch point** — `findBlockRange` delegates through `narrowLineInBlock` for both single-block and cross-block selections

## Tests

18 new unit tests added (55 total, all passing via `node --test`):
- `findTrLineInBlock`: thead, tbody row 0/1, non-table node, text-node input
- `findLiLineInBlock`: first/third item, not-in-list, nested list document order
- `findCodeLineInBlock`: no-pre block, offset 0, after 1 newline, second text-node, not-found
- `narrowLineInBlock`: table dispatch, list dispatch, plain paragraph (null), single-row

## Design rationale

Precision is intentionally approximate for lists and code — the primary consumer is AI feedback loops where ±1 line is acceptable. The goal is to avoid exporting `L1–L80` for an 80-line code block when the user selected line 42.
