### PR TITLE
feat(workspace): add navigation history, link handling, and table scroll

### DIFF
--- a/chrome/src/workspace/file-icons.ts
+++ b/chrome/src/workspace/file-icons.ts
@@ -13,6 +13,10 @@ export const closeIcon = `<svg ${A}><path d="M18 6 6 18"/><path d="m6 6 12 12"/>
 export const fileSearchIcon = `<svg ${A}><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/></svg>`;
 export const textSearchIcon = `<svg ${A}><path d="M4 7V4h16v3"/><path d="M9 20h6"/><path d="M12 4v16"/></svg>`;
 
+// ─── Navigation icons (Lucide, stroke-based, follows currentColor) ───
+export const arrowLeft = `<svg ${A}><path d="m12 19-7-7 7-7"/><path d="M19 12H5"/></svg>`;
+export const arrowRight = `<svg ${A}><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>`;
+
 // ─── Folder icons (Lucide, stroke-based, follows currentColor) ───
 export const folderClosed = `<svg ${A}><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></svg>`;
 export const folderOpen = `<svg ${A}><path d="m6 14 1.5-2.9A2 2 0 0 1 9.24 10H20a2 2 0 0 1 1.94 2.5l-1.54 6a2 2 0 0 1-1.95 1.5H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h3.9a2 2 0 0 1 1.69.9l.81 1.2a2 2 0 0 0 1.67.9H18a2 2 0 0 1 2 2v2"/></svg>`;

--- a/chrome/src/workspace/viewer-embed.ts
+++ b/chrome/src/workspace/viewer-embed.ts
@@ -16,16 +16,9 @@ import type {
   ViewerIframeMessage,
   ViewerOpenDocumentMessage,
   ViewerUpdateContentMessage,
-  ViewerSyncHostNavigationMessage,
-  ViewerSyncHostUiMessage,
 } from '../../../src/integration/iframe-viewer-host';
 
-type OpenDocumentMessage = ViewerOpenDocumentMessage;
-type UpdateContentMessage = ViewerUpdateContentMessage;
-type SyncHostUiMessage = ViewerSyncHostUiMessage;
-type SyncHostNavigationMessage = ViewerSyncHostNavigationMessage;
-type ViewerEmbedMessage = ViewerIframeMessage;
-type DocumentMessage = OpenDocumentMessage | UpdateContentMessage;
+type DocumentMessage = ViewerOpenDocumentMessage | ViewerUpdateContentMessage;
 
 let initialized = false;
 const EMBED_MODE = new URLSearchParams(window.location.search).get('embed') === '1';
@@ -98,14 +91,6 @@ if (EMBED_MODE) {
   (document.head || document.documentElement).appendChild(style);
 }
 
-function syncHostUi(message: SyncHostUiMessage): void {
-  hostUiController.syncHostUi(message);
-}
-
-function syncHostNavigation(message: SyncHostNavigationMessage): void {
-  parentBridge.syncHostNavigation(message);
-}
-
 function scrollToAnchor(anchor: string): void {
   const normalized = decodeURIComponent(anchor || '').replace(/^#/, '').trim();
   if (!normalized) return;
@@ -132,7 +117,7 @@ function normalizeTargetLine(value: unknown): number | undefined {
   return Math.max(1, Math.floor(value));
 }
 
-function applyOpenDocumentMetadata(message: OpenDocumentMessage): void {
+function applyOpenDocumentMetadata(message: ViewerOpenDocumentMessage): void {
   const filename = String(message.filename || 'inline.md');
   const workspaceName = String(message.workspaceName || '');
   const workspaceFilePath = String(message.workspaceFilePath || '');
@@ -148,6 +133,32 @@ function applyOpenDocumentMetadata(message: OpenDocumentMessage): void {
   }
 
   applyCodeViewPresentation(codeView);
+
+  const fileNameSpan = document.getElementById('file-name');
+  if (fileNameSpan) {
+    fileNameSpan.textContent = filename;
+  }
+  document.title = filename;
+}
+
+let navToggleInjected = false;
+function injectNavToggleButton(): void {
+  if (navToggleInjected) return;
+  const toolbarCenter = document.querySelector('.toolbar-center');
+  if (!toolbarCenter) return;
+  navToggleInjected = true;
+
+  const btn = document.createElement('button');
+  btn.className = 'toolbar-btn';
+  btn.title = 'Toggle Navigation Bar';
+  btn.setAttribute('aria-label', 'Toggle Navigation Bar');
+  btn.innerHTML = `<svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor">
+    <path d="M4 10l3-3M4 10l3 3M16 10l-3-3M16 10l-3 3M4 10h12" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  </svg>`;
+  btn.addEventListener('click', () => {
+    window.parent.postMessage({ type: 'TOGGLE_NAV_BAR' }, '*');
+  });
+  toolbarCenter.appendChild(btn);
 }
 
 async function ensureViewerInitialized(initialContent: string): Promise<{
@@ -171,8 +182,11 @@ async function ensureViewerInitialized(initialContent: string): Promise<{
     });
   }
 
+  const runtime = await waitForViewerMainRuntime();
+  injectNavToggleButton();
+
   return {
-    runtime: await waitForViewerMainRuntime(),
+    runtime,
     wasInitialized,
   };
 }
@@ -188,7 +202,7 @@ async function handleDocumentMessage(message: DocumentMessage, mode: 'open' | 'u
   const targetLine = normalizeTargetLine(message.targetLine);
 
   if (mode === 'open') {
-    applyOpenDocumentMetadata(message as OpenDocumentMessage);
+    applyOpenDocumentMetadata(message as ViewerOpenDocumentMessage);
   }
 
   const { runtime, wasInitialized } = await ensureViewerInitialized(content);
@@ -207,7 +221,7 @@ async function handleDocumentMessage(message: DocumentMessage, mode: 'open' | 'u
   parentBridge.notifyViewerRendered();
 }
 
-function handleViewerMessage(data: ViewerEmbedMessage): void {
+function handleViewerMessage(data: ViewerIframeMessage): void {
   switch (data.type) {
     case 'OPEN_DOCUMENT':
       void handleDocumentMessage(data, 'open');
@@ -216,10 +230,10 @@ function handleViewerMessage(data: ViewerEmbedMessage): void {
       void handleDocumentMessage(data, 'update');
       return;
     case 'SYNC_HOST_UI':
-      syncHostUi(data);
+      hostUiController.syncHostUi(data);
       return;
     case 'SYNC_HOST_NAVIGATION':
-      syncHostNavigation(data);
+      parentBridge.syncHostNavigation(data);
       return;
     default:
       return;
@@ -227,4 +241,31 @@ function handleViewerMessage(data: ViewerEmbedMessage): void {
 }
 
 parentBridge.bindViewerMessages(handleViewerMessage);
+
+// Intercept clicks on relative file links and delegate to the workspace parent.
+// Without this, the browser navigates the iframe to a non-existent chrome-extension:// URL.
+document.addEventListener('click', (event) => {
+  const anchor = (event.target as HTMLElement).closest?.('a');
+  if (!anchor) return;
+
+  const href = anchor.getAttribute('href');
+  if (!href) return;
+
+  // Anchor-only links (#heading) are handled by the viewer's hashchange logic
+  if (href.startsWith('#')) return;
+
+  // All non-anchor links must preventDefault to avoid navigating the iframe away
+  // from the viewer page (which would destroy the viewer runtime).
+  event.preventDefault();
+
+  // Absolute URLs (http:, mailto:, tel:, etc.) open via window.open
+  if (/^[a-z][a-z0-9+\-.]*:/i.test(href)) {
+    window.open(href, '_blank');
+    return;
+  }
+
+  // Relative path — delegate to workspace parent to open via File System Access API
+  window.parent.postMessage({ type: 'WORKSPACE_NAVIGATE', path: href }, '*');
+});
+
 parentBridge.notifyViewerReady();

--- a/chrome/src/workspace/workspace-embed-host-ui.ts
+++ b/chrome/src/workspace/workspace-embed-host-ui.ts
@@ -282,7 +282,7 @@ export function createWorkspaceEmbedHostUiController(
           (item as HTMLElement).style.display = level > maxDepth ? 'none' : '';
         });
       }
-    } else {
+    } else if (tocMode === 'none') {
       destroyFloatingTocPanel();
       if (tocDiv) {
         tocDiv.classList.add('hidden');
@@ -290,6 +290,8 @@ export function createWorkspaceEmbedHostUiController(
       }
       document.body.classList.add('toc-hidden');
     }
+    // When tocMode is undefined (host never sent a toc setting),
+    // leave the viewer's own TOC management untouched.
   };
 
   const applyPendingHostUiEffects = (): void => {

--- a/chrome/src/workspace/workspace.css
+++ b/chrome/src/workspace/workspace.css
@@ -365,21 +365,59 @@ html, body {
 .preview-pane {
   flex: 1;
   display: flex;
-  align-items: center;
-  justify-content: center;
+  flex-direction: column;
   overflow: hidden;
   background: var(--color-bg-surface);
   position: relative;
 }
 
+/* Navigation bar */
+.preview-nav {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 4px 8px;
+  height: 36px;
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-bg-surface);
+  flex-shrink: 0;
+}
+
+.nav-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px 6px;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  color: var(--color-text-primary);
+}
+.nav-btn svg { width: 16px; height: 16px; }
+.nav-btn:hover:not(:disabled) { background: var(--color-bg-hover); }
+.nav-btn:disabled { color: var(--color-text-tertiary); opacity: 0.4; cursor: default; }
+
+.nav-filename {
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  margin-left: 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .preview-empty {
   color: var(--color-text-tertiary);
   font-size: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
 }
 
 .preview-frame {
   width: 100%;
-  height: 100%;
+  flex: 1;
   border: none;
   /* Paint the iframe element itself with the surface color so the brief
      blank frame between navigations (file switch / refresh) doesn't flash

--- a/chrome/src/workspace/workspace.html
+++ b/chrome/src/workspace/workspace.html
@@ -33,6 +33,15 @@
   <!-- Workspace layout -->
   <div id="workspace" class="workspace" style="display:none;">
     <div class="preview-pane">
+      <div id="preview-nav" class="preview-nav" style="display:none;">
+        <button id="nav-back" class="nav-btn" disabled>
+          <span id="nav-back-icon"></span>
+        </button>
+        <button id="nav-forward" class="nav-btn" disabled>
+          <span id="nav-forward-icon"></span>
+        </button>
+        <span id="nav-filename" class="nav-filename"></span>
+      </div>
       <div id="preview-empty" class="preview-empty">
         <p data-i18n="workspace_select_file">Select a file to preview</p>
       </div>

--- a/chrome/src/workspace/workspace.ts
+++ b/chrome/src/workspace/workspace.ts
@@ -6,7 +6,7 @@ import { getWebExtensionApi } from '../../../src/utils/platform-info';
 import Localization, { DEFAULT_SETTING_LOCALE } from '../../../src/utils/localization';
 import { applyI18nText } from '../../../src/ui/popup/i18n-helpers';
 import { ALL_SUPPORTED_EXTENSIONS } from '../../../src/types/formats';
-import { chevronRight, chevronDown, folderClosed, folderOpen, folderPlus, searchIcon, fileSearchIcon, textSearchIcon, getFileIcon } from './file-icons';
+import { chevronRight, chevronDown, folderClosed, folderOpen, folderPlus, searchIcon, fileSearchIcon, textSearchIcon, arrowLeft, arrowRight, getFileIcon } from './file-icons';
 import themeManager from '../../../src/utils/theme-manager';
 import { createViewerIframeHostBridge } from '../../../src/integration/iframe-viewer-host';
 
@@ -65,12 +65,46 @@ const $previewFrame = document.getElementById('preview-frame') as HTMLIFrameElem
 const $previewEmptyText = $previewEmpty.querySelector('p');
 const $recentWorkspaces = document.getElementById('recent-workspaces')!;
 const $recentList = document.getElementById('recent-list')!;
+const $previewNav = document.getElementById('preview-nav')!;
+const $navBack = document.getElementById('nav-back') as HTMLButtonElement;
+const $navForward = document.getElementById('nav-forward') as HTMLButtonElement;
+const $navFilename = document.getElementById('nav-filename')!;
 
 let rootDirHandle: FileSystemDirectoryHandle | null = null;
 let currentFileDir = '';
 let swapPanelSide = false;
 let activeFilePath = '';
 let currentSearchQuery = '';
+
+// ─── Navigation history ───
+const navHistory: string[] = [];
+let navIndex = -1;
+let navInProgress = false;
+let navBarHidden = false;
+
+async function loadNavBarHidden(): Promise<void> {
+  try {
+    const result = await webExtensionApi.storage.local.get(['markdownViewerSettings']);
+    const stored = result.markdownViewerSettings as { workspaceNavBarHidden?: boolean } | undefined;
+    navBarHidden = Boolean(stored?.workspaceNavBarHidden);
+  } catch { /* keep default */ }
+}
+
+async function saveNavBarHidden(): Promise<void> {
+  try {
+    const storageLocal = webExtensionApi.storage.local as {
+      get: (keys: string | string[] | Record<string, unknown>) => Promise<Record<string, unknown>>;
+      set?: (items: Record<string, unknown>) => Promise<void>;
+    };
+    const result = await storageLocal.get(['markdownViewerSettings']);
+    const current = (result.markdownViewerSettings as Record<string, unknown>) || {};
+    if (typeof storageLocal.set === 'function') {
+      await storageLocal.set({
+        markdownViewerSettings: { ...current, workspaceNavBarHidden: navBarHidden },
+      });
+    }
+  } catch { /* ignore */ }
+}
 let workspaceTree: TreeNode[] = [];
 const expandedPaths = new Set<string>();
 let currentSearchMode: SearchMode = 'filename';
@@ -260,6 +294,8 @@ window.addEventListener('resize', updateResizeHandlePosition);
 document.getElementById('pick-icon')!.innerHTML = folderPlus;
 $changeBtn.innerHTML = folderPlus;
 $toggleSearchBtn.innerHTML = searchIcon;
+document.getElementById('nav-back-icon')!.innerHTML = arrowLeft;
+document.getElementById('nav-forward-icon')!.innerHTML = arrowRight;
 
 // ─── Extension matching ───
 function isSupportedFile(name: string): boolean {
@@ -883,6 +919,40 @@ function toggleSearchMode(): void {
   $fileSearchInput.select();
 }
 
+// ─── Navigation history ───
+function pushNavHistory(filePath: string): void {
+  if (navInProgress) return;
+  if (navHistory[navIndex] === filePath) return;
+  navHistory.splice(navIndex + 1);
+  navHistory.push(filePath);
+  navIndex = navHistory.length - 1;
+  updateNavButtons();
+}
+
+function updateNavButtons(): void {
+  $navBack.disabled = navIndex <= 0;
+  $navForward.disabled = navIndex >= navHistory.length - 1;
+  const current = navHistory[navIndex];
+  $navFilename.textContent = current ? current.split('/').pop() || '' : '';
+  $previewNav.style.display = !navBarHidden && navHistory.length > 0 ? '' : 'none';
+}
+
+async function navigateHistory(index: number): Promise<void> {
+  if (index < 0 || index >= navHistory.length) return;
+  const filePath = navHistory[index];
+  navIndex = index;
+  navInProgress = true;
+  updateNavButtons();
+  try {
+    await navigateToWorkspaceFile(filePath);
+  } finally {
+    navInProgress = false;
+  }
+}
+
+$navBack.addEventListener('click', () => navigateHistory(navIndex - 1));
+$navForward.addEventListener('click', () => navigateHistory(navIndex + 1));
+
 // ─── Resolve relative path against file directory ───
 function resolveRelativePath(fileDir: string, relativePath: string): string {
   const parts = fileDir.split('/').filter(Boolean);
@@ -948,6 +1018,8 @@ async function openFile(fileHandle: FileSystemFileHandle, options?: { targetLine
   const name = fileHandle.name;
   const workspaceFilePath = currentFileDir + name;
 
+  pushNavHistory(workspaceFilePath);
+
   // Save last opened file path
   sessionStorage.setItem(`workspace-last-file:${rootDirHandle?.name}`, workspaceFilePath);
 
@@ -995,8 +1067,15 @@ async function openWorkspace(dirHandle: FileSystemDirectoryHandle) {
   currentSearchMode = 'filename';
   $previewEmpty.style.display = '';
   $previewFrame.style.display = 'none';
+  $previewNav.style.display = 'none';
   resetPreviewFrameState();
   $previewFrame.src = 'about:blank';
+
+  // Reset navigation history
+  navHistory.length = 0;
+  navIndex = -1;
+  navInProgress = false;
+  updateNavButtons();
 
   rootDirHandle = dirHandle;
   directoryReadCache.clear();
@@ -1152,6 +1231,13 @@ $fileSearchInput.addEventListener('keydown', (event: KeyboardEvent) => {
 window.addEventListener('message', async (event: MessageEvent) => {
   if (event.source !== $previewFrame.contentWindow) return;
 
+  if (event.data?.type === 'TOGGLE_NAV_BAR') {
+    navBarHidden = !navBarHidden;
+    updateNavButtons();
+    void saveNavBarHidden();
+    return;
+  }
+
   if (event.data?.type === 'RESOLVE_IMAGE') {
     const { src, id } = event.data;
     const resolved = resolveRelativePath(currentFileDir, src);
@@ -1159,6 +1245,18 @@ window.addEventListener('message', async (event: MessageEvent) => {
     if (file) {
       const url = URL.createObjectURL(file);
       $previewFrame.contentWindow!.postMessage({ type: 'IMAGE_RESOLVED', id, url }, '*');
+    }
+    return;
+  }
+
+  // Relative link clicks from the rendered markdown inside the iframe
+  if (event.data?.type === 'WORKSPACE_NAVIGATE') {
+    const rawPath = String(event.data.path || '');
+    const hashIndex = rawPath.indexOf('#');
+    const pathOnly = hashIndex >= 0 ? rawPath.slice(0, hashIndex) : rawPath;
+    if (pathOnly) {
+      const resolved = resolveRelativePath(currentFileDir, pathOnly);
+      void navigateToWorkspaceFile(resolved);
     }
     return;
   }
@@ -1191,6 +1289,28 @@ window.addEventListener('message', async (event: MessageEvent) => {
     }
   }
 });
+
+// ─── Navigate to a workspace file (from markdown link click) ───
+async function navigateToWorkspaceFile(filePath: string): Promise<void> {
+  if (!rootDirHandle) return;
+  const segments = filePath.split('/').filter(Boolean);
+  if (segments.length === 0) return;
+  const fileName = segments[segments.length - 1];
+  const dirPath = segments.length > 1 ? segments.slice(0, -1).join('/') + '/' : '';
+
+  let dir = rootDirHandle;
+  for (let i = 0; i < segments.length - 1; i++) {
+    try { dir = await dir.getDirectoryHandle(segments[i]); }
+    catch { return; }
+  }
+  try {
+    const fh = await dir.getFileHandle(fileName);
+    activeFilePath = filePath;
+    currentFileDir = dirPath;
+    void syncTreeToActiveFile(filePath);
+    openFile(fh);
+  } catch { /* file not found */ }
+}
 
 // ─── Restore last file ───
 async function restoreLastFile(filePath: string): Promise<void> {
@@ -1324,6 +1444,7 @@ async function syncDarkClassFromSelectedTheme(): Promise<void> {
 Localization.init().then(async () => {
   await syncDarkClassFromSelectedTheme();
   await loadWorkspacePanelSide();
+  await loadNavBarHidden();
 
   if (webExtensionApi.storage?.onChanged) {
     webExtensionApi.storage.onChanged.addListener((changes, areaName) => {

--- a/src/utils/theme-to-css.ts
+++ b/src/utils/theme-to-css.ts
@@ -353,23 +353,27 @@ ${styles.join('\n')}
 function generateTableCSS(tableStyle: TableStyleConfig, colorScheme: ColorScheme): string {
   const css: string[] = [];
 
-  // Base table styles - default to centered auto width.
+  // Base table styles - display:block + overflow-x:auto enables horizontal
+  // scrolling for wide tables while width:fit-content + margin:auto preserves
+  // centering for narrow ones.
   css.push(`#markdown-content table {
   border-collapse: collapse;
+  display: block;
+  overflow-x: auto;
+  width: fit-content;
+  max-width: 100%;
   margin: 13px auto;
-  overflow: auto;
 }
 
 /* Table layout: left alignment */
 #markdown-content.table-layout-left table {
-  width: auto;
   margin-left: 0;
   margin-right: auto;
 }
 
 /* Table layout: centered auto width */
 #markdown-content.table-layout-center table {
-  width: auto;
+  width: fit-content;
 }
 
 /* Table layout: full width */

--- a/test/theme-table-css.test.ts
+++ b/test/theme-table-css.test.ts
@@ -1,0 +1,131 @@
+import assert from 'assert';
+import { describe, it } from 'node:test';
+import { themeToCSS } from '../src/utils/theme-to-css';
+import type { ThemeConfig, TableStyleConfig, CodeThemeConfig, LayoutScheme } from '../src/utils/theme-to-css';
+import type { ColorScheme } from '../src/types/theme';
+
+const minimalColorScheme: ColorScheme = {
+  id: 'test',
+  name: 'Test',
+  name_en: 'Test',
+  description: 'Test color scheme',
+  text: { primary: '#000', secondary: '#333', muted: '#666' },
+  accent: { link: '#00f', linkHover: '#00d' },
+  background: { code: '#f5f5f5' },
+  blockquote: { border: '#ddd' },
+  table: {
+    border: '#ccc',
+    headerBackground: '#f0f0f0',
+    headerText: '#000',
+    zebraEven: '#fff',
+    zebraOdd: '#fafafa',
+  },
+};
+
+const minimalTableStyle: TableStyleConfig = {
+  header: { fontWeight: 'bold' },
+  cell: { padding: '8px 12px' },
+};
+
+const minimalTheme: ThemeConfig = {
+  fontScheme: {
+    body: { fontFamily: 'sans-serif' },
+    headings: { fontFamily: 'sans-serif' },
+    code: { fontFamily: 'monospace' },
+  },
+  layoutScheme: 'regular',
+  colorScheme: 'github-light',
+  tableStyle: 'classic',
+  codeTheme: 'github-light',
+};
+
+const minimalLayout: LayoutScheme = {
+  id: 'test',
+  name: 'Test',
+  name_en: 'Test',
+  description: 'Test layout',
+  body: { fontSize: '12pt', lineHeight: 1.6 },
+  headings: {
+    h1: { fontSize: '24pt', spacingBefore: '24pt', spacingAfter: '12pt' },
+    h2: { fontSize: '20pt', spacingBefore: '20pt', spacingAfter: '10pt' },
+    h3: { fontSize: '16pt', spacingBefore: '16pt', spacingAfter: '8pt' },
+    h4: { fontSize: '14pt', spacingBefore: '14pt', spacingAfter: '6pt' },
+    h5: { fontSize: '12pt', spacingBefore: '12pt', spacingAfter: '4pt' },
+    h6: { fontSize: '10pt', spacingBefore: '10pt', spacingAfter: '4pt' },
+  },
+  code: { fontSize: '10pt' },
+  blocks: {
+    paragraph: { spacingAfter: '12pt' },
+    list: { spacingAfter: '12pt' },
+    listItem: {},
+    blockquote: { spacingAfter: '12pt', paddingVertical: '8pt', paddingHorizontal: '16pt' },
+    codeBlock: { spacingAfter: '12pt', paddingVertical: '12pt', paddingHorizontal: '16pt' },
+    table: { spacingAfter: '12pt' },
+    horizontalRule: { spacingBefore: '12pt', spacingAfter: '12pt' },
+  },
+};
+
+const minimalCodeTheme: CodeThemeConfig = {
+  colors: {},
+  foreground: '#000',
+};
+
+function generateCSS(): string {
+  return themeToCSS(minimalTheme, minimalLayout, minimalColorScheme, minimalTableStyle, minimalCodeTheme);
+}
+
+describe('Table CSS Generation', () => {
+  it('generates display:block for horizontal scroll support', () => {
+    const css = generateCSS();
+    assert.ok(css.includes('display: block'), 'table should use display:block for scroll container');
+  });
+
+  it('generates overflow-x:auto for wide tables', () => {
+    const css = generateCSS();
+    assert.ok(css.includes('overflow-x: auto'), 'table should have overflow-x:auto');
+  });
+
+  it('generates width:fit-content for centering narrow tables', () => {
+    const css = generateCSS();
+    assert.ok(css.includes('width: fit-content'), 'table should use fit-content width');
+  });
+
+  it('generates max-width:100% to constrain within container', () => {
+    const css = generateCSS();
+    assert.ok(css.includes('max-width: 100%'), 'table should have max-width:100%');
+  });
+
+  it('generates margin:auto for centering', () => {
+    const css = generateCSS();
+    assert.ok(css.includes('margin: 13px auto'), 'table should be centered with margin:auto');
+  });
+
+  it('generates left-aligned layout variant', () => {
+    const css = generateCSS();
+    assert.ok(
+      css.includes('.table-layout-left table'),
+      'should include left layout variant',
+    );
+    assert.ok(css.includes('margin-left: 0'), 'left layout should have margin-left:0');
+  });
+
+  it('generates center layout variant with fit-content', () => {
+    const css = generateCSS();
+    const centerMatch = css.match(
+      /\.table-layout-center table\s*\{[^}]*width:\s*fit-content/,
+    );
+    assert.ok(centerMatch, 'center layout should use fit-content width');
+  });
+
+  it('generates full-width layout variant', () => {
+    const css = generateCSS();
+    assert.ok(
+      css.includes('.table-layout-center-full-width table'),
+      'should include full-width layout variant',
+    );
+    assert.ok(
+      css.includes('width: 100%'),
+      'full-width layout should set width:100%',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- **Navigation history**: Back/forward buttons in a new nav bar above the preview pane, with browser-like history tracking. Nav bar toggle button in the viewer toolbar with persisted show/hide state.
- **Link handling**: Intercept all link clicks inside the viewer iframe — external URLs (http, mailto, tel) open via `window.open` instead of navigating the iframe away; relative paths route through the workspace file resolver.
- **TOC fix**: Only hide TOC when host explicitly sends `tocMode: 'none'`; leave viewer's own TOC management untouched when undefined.
- **File-name fix**: Update `#file-name` span and `document.title` on every file switch.
- **Table horizontal scroll**: Wide tables now scroll horizontally within their own container (`display: block; overflow-x: auto; width: fit-content; max-width: 100%`) while narrow tables remain centered.

## Test plan

- [ ] Open workspace, click files in sidebar — verify nav bar appears with filename
- [ ] Click back/forward buttons — verify history navigation works
- [ ] Click nav toggle button in toolbar — verify nav bar hides/shows and state persists across reload
- [ ] Click relative markdown links — verify file opens in viewer
- [ ] Click email links (mailto:) — verify opens mail client, viewer doesn't freeze
- [ ] Click external URLs (http/https) — verify opens in new tab
- [ ] Verify TOC sidebar shows correctly after navigation
- [ ] Open a markdown file with a wide table (many columns) — verify horizontal scroll within the table
- [ ] Open a markdown file with a narrow table — verify it remains centered

Demo: https://vimeo.com/1194088302?share=copy&fl=sv&fe=ci