### PR TITLE
feat(chrome): add development workflow and workspace drag-and-drop

### DIFF
--- a/chrome/build-config.js
+++ b/chrome/build-config.js
@@ -16,6 +16,7 @@ const createChromiumBuildOptions = (overrides = {}) => {
     platformTag = 'chrome',
     readyMessage = 'chrome://extensions/ -> Load unpacked -> select dist/chrome/',
     extraCopyDirectories = [],
+    development = false,
   } = overrides;
 
   return {
@@ -26,6 +27,7 @@ const createChromiumBuildOptions = (overrides = {}) => {
     platformTag,
     readyMessage,
     extraCopyDirectories,
+    development,
   };
 };
 
@@ -106,7 +108,7 @@ export const createBuildConfig = (overrides = {}) => {
     metafile: false, // Generate metafile for bundle analysis
     // Define globals
     define: {
-      'process.env.NODE_ENV': '"production"',
+      'process.env.NODE_ENV': options.development ? '"development"' : '"production"',
       'MV_PLATFORM': `"${options.platformTag}"`,
       'MV_RUNTIME': '"shared"',
       'global': 'globalThis', // Polyfill for global
@@ -123,8 +125,8 @@ export const createBuildConfig = (overrides = {}) => {
     assetNames: '[name]', // Use original filename without hash
     // Mermaid is loaded separately via script tag to keep bundle size manageable
     external: ['mermaid', 'web-worker'],
-    minify: true,
-    sourcemap: false,
+    minify: !options.development,
+    sourcemap: options.development,
     plugins: [
       dagreShimPlugin,
       // Redirect @markdown-viewer/drawio2svg and draw-uml imports to shims

--- a/chrome/dev.js
+++ b/chrome/dev.js
@@ -1,0 +1,82 @@
+import { context } from 'esbuild';
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { createBuildConfig } from './build-config.js';
+
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+process.chdir(projectRoot);
+
+console.log('📦 Building Slidev assets...');
+execSync('npm run build:slidev-shell', { stdio: 'inherit' });
+execSync('node --import tsx slidev-shell/build-themes.ts', { stdio: 'inherit' });
+
+const outdir = path.join(projectRoot, 'dist/chrome');
+fs.rmSync(outdir, { recursive: true, force: true });
+
+const buildContext = await context(createBuildConfig({ development: true }));
+await buildContext.watch();
+
+const staticTargets = [
+  'chrome/manifest.json',
+  'chrome/src/popup',
+  'chrome/src/workspace',
+  'chrome/src/webview/offscreen-render.html',
+  'icons',
+  'src/_locales',
+  'src/themes',
+];
+
+function getStaticSnapshot() {
+  const files = [];
+
+  function collect(target) {
+    const stat = fs.statSync(target);
+    if (stat.isDirectory()) {
+      fs.readdirSync(target).forEach((entry) => collect(path.join(target, entry)));
+      return;
+    }
+
+    if (!['.ts', '.tsx'].includes(path.extname(target))) {
+      files.push(`${target}:${stat.mtimeMs}:${stat.size}`);
+    }
+  }
+
+  staticTargets.forEach((target) => collect(path.join(projectRoot, target)));
+  return files.sort().join('|');
+}
+
+let previousSnapshot = getStaticSnapshot();
+const pollTimer = setInterval(() => {
+  const nextSnapshot = getStaticSnapshot();
+  if (nextSnapshot === previousSnapshot) return;
+
+  previousSnapshot = nextSnapshot;
+  buildContext.rebuild()
+    .then(() => console.log('🔄 Static assets updated'))
+    .catch((error) => console.error('❌ Static asset rebuild failed:', error));
+}, 500);
+
+console.log('\n👀 Chrome development build is watching for changes');
+console.log('   Load dist/chrome in chrome://extensions/');
+console.log('   After a rebuild, reload the extension and refresh the test page.');
+console.log('   Restart this command after changing slidev-shell/.\n');
+
+let stopping = false;
+async function stop() {
+  if (stopping) return;
+  stopping = true;
+  clearInterval(pollTimer);
+  await buildContext.dispose();
+}
+
+process.once('SIGINT', async () => {
+  await stop();
+  process.exit(0);
+});
+
+process.once('SIGTERM', async () => {
+  await stop();
+  process.exit(0);
+});

--- a/chrome/src/popup/popup.css
+++ b/chrome/src/popup/popup.css
@@ -388,6 +388,7 @@ h1.clickable-title:hover {
 .btn-project {
   width: 100%;
   padding: 10px 16px;
+  margin-bottom: 15px;
   gap: 8px;
   background: var(--color-primary-light);
   border-color: var(--color-primary-subtle);
@@ -530,14 +531,13 @@ h1.clickable-title:hover {
   cursor: pointer;
   transition: all var(--transition-fast);
   padding: 12px;
-  border-left: 3px solid transparent;
   position: relative;
   padding-right: 42px;
 }
 
 .history-item:hover {
   background: var(--gray-50);
-  border-left-color: var(--color-primary);
+  border-left: 3px solid var(--color-primary);
   transform: translateX(2px);
 }
 

--- a/chrome/src/popup/popup.html
+++ b/chrome/src/popup/popup.html
@@ -36,11 +36,9 @@
       <!-- History tab (merged with overview) -->
       <div class="tab-panel active" id="history">
         <!-- Open Project button -->
-        <div class="info-section" style="padding-bottom: 0;">
-          <button class="btn btn-project" id="open-project-btn">
-            <span class="btn-icon" aria-hidden="true">↗</span> <span data-i18n="workspace_open">Open Workspace</span>
-          </button>
-        </div>
+        <button class="btn btn-project" id="open-project-btn">
+          <span class="btn-icon" aria-hidden="true">↗</span> <span data-i18n="workspace_open">Open Workspace</span>
+        </button>
 
         <!-- File access warning (only shown when permission is disabled) -->
         <div id="file-access-warning" class="warning-box" style="display: none;">

--- a/chrome/src/workspace/workspace.css
+++ b/chrome/src/workspace/workspace.css
@@ -73,7 +73,7 @@ html, body {
 
 .landing-card {
   text-align: center;
-  max-width: 400px;
+  width: min(560px, 100%);
   padding: 48px 32px;
 }
 
@@ -98,6 +98,31 @@ html, body {
 .landing-btn:hover { background: var(--color-primary-hover); }
 .landing-btn-icon { display: flex; align-items: center; }
 .landing-btn-icon svg { width: 18px; height: 18px; }
+.drop-overlay {
+  position: fixed;
+  inset: 12px;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 28px;
+  border: 2px dashed var(--color-primary);
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--color-bg-surface) 88%, transparent);
+  color: var(--color-primary);
+  font-weight: 600;
+  text-align: center;
+  backdrop-filter: blur(4px);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.15s, visibility 0.15s;
+}
+
+.drop-overlay.visible {
+  opacity: 1;
+  visibility: visible;
+}
 
 /* Recent workspaces */
 .recent-workspaces { margin-top: 40px; text-align: left; }

--- a/chrome/src/workspace/workspace.html
+++ b/chrome/src/workspace/workspace.html
@@ -16,13 +16,12 @@
     <div class="landing-card">
       <img src="../../icons/icon48.png" alt="Logo" class="landing-logo">
       <h1 class="landing-title" data-i18n="workspace_title">Workspace</h1>
-      <p class="landing-desc" data-i18n="workspace_desc">Open a local directory to browse and preview supported files.</p>
+      <p class="landing-desc" data-i18n="workspace_desc">Open a local directory or drop files and folders here to browse and preview supported files.</p>
 
       <button id="pick-directory" class="landing-btn">
         <span id="pick-icon" class="landing-btn-icon"></span>
         <span data-i18n="workspace_choose_directory">Choose Directory</span>
       </button>
-
       <div id="recent-workspaces" class="recent-workspaces" style="display:none;">
         <h3 class="recent-title" data-i18n="workspace_recent">Recent Workspaces</h3>
         <div id="recent-list" class="recent-list"></div>
@@ -53,6 +52,10 @@
       </div>
       <div id="file-tree" class="file-tree"></div>
     </div>
+  </div>
+
+  <div id="drop-overlay" class="drop-overlay" data-i18n="workspace_desc" aria-hidden="true">
+    Open a local directory or drop files and folders here to browse and preview supported files.
   </div>
 
   <script src="workspace.js"></script>

--- a/chrome/src/workspace/workspace.ts
+++ b/chrome/src/workspace/workspace.ts
@@ -66,6 +66,7 @@ const $previewFrame = document.getElementById('preview-frame') as HTMLIFrameElem
 const $previewEmptyText = $previewEmpty.querySelector('p');
 const $recentWorkspaces = document.getElementById('recent-workspaces')!;
 const $recentList = document.getElementById('recent-list')!;
+const $dropOverlay = document.getElementById('drop-overlay')!;
 
 let rootDirHandle: FileSystemDirectoryHandle | null = null;
 let currentFileDir = '';
@@ -85,6 +86,7 @@ let lastExecutedContentQuery = '';
 let contentSearchInProgress = false;
 let contentSearchRunId = 0;
 const directoryReadCache = new Map<string, Promise<TreeNode[]>>();
+const droppedFileHandles = new Map<string, FileSystemFileHandle>();
 
 function postToPreviewFrame(message: ViewerIframeMessage | { type: string; [key: string]: unknown }): void {
   $previewFrame.contentWindow?.postMessage(message, '*');
@@ -936,7 +938,15 @@ function resolveRelativePath(fileDir: string, relativePath: string): string {
 }
 
 async function resolveFileFromRoot(path: string): Promise<File | null> {
-  if (!rootDirHandle) return null;
+  if (!rootDirHandle) {
+    const droppedHandle = droppedFileHandles.get(path);
+    if (!droppedHandle) return null;
+    try {
+      return await droppedHandle.getFile();
+    } catch {
+      return null;
+    }
+  }
   const segments = path.split('/').filter(Boolean);
   if (segments.length === 0) return null;
   let dir = rootDirHandle;
@@ -993,7 +1003,9 @@ async function openFile(fileHandle: FileSystemFileHandle, options?: { targetLine
   pushNavHistory(workspaceFilePath);
 
   // Save last opened file path
-  sessionStorage.setItem(`workspace-last-file:${rootDirHandle?.name}`, workspaceFilePath);
+  if (rootDirHandle) {
+    sessionStorage.setItem(`workspace-last-file:${rootDirHandle.name}`, workspaceFilePath);
+  }
 
   const ext = name.slice(name.lastIndexOf('.') + 1).toLowerCase();
 
@@ -1028,11 +1040,11 @@ async function openFile(fileHandle: FileSystemFileHandle, options?: { targetLine
 }
 
 // ─── Open workspace ───
-async function openWorkspace(dirHandle: FileSystemDirectoryHandle) {
+function prepareWorkspaceView(name: string): void {
   $landing.style.display = 'none';
   $workspace.style.display = 'flex';
   requestAnimationFrame(updateResizeHandlePosition);
-  $workspaceName.textContent = dirHandle.name;
+  $workspaceName.textContent = name;
   clearSearch(true);
   expandedPaths.clear();
   activeFilePath = '';
@@ -1047,8 +1059,12 @@ async function openWorkspace(dirHandle: FileSystemDirectoryHandle) {
   navIndex = -1;
   navInProgress = false;
   updateNavButtons();
+}
 
+async function openWorkspace(dirHandle: FileSystemDirectoryHandle) {
+  prepareWorkspaceView(dirHandle.name);
   rootDirHandle = dirHandle;
+  droppedFileHandles.clear();
   directoryReadCache.clear();
   workspaceTree = await getCachedDirectoryEntries(dirHandle, '');
   renderTreeView();
@@ -1171,6 +1187,93 @@ async function pickAndOpen() {
     // User cancelled picker
   }
 }
+
+async function openDroppedItems(dataTransfer: DataTransfer): Promise<void> {
+  const fileHandles: FileSystemFileHandle[] = [];
+
+  for (const item of Array.from(dataTransfer.items)) {
+    if (item.kind !== 'file') continue;
+
+    let handle: FileSystemHandle | null = null;
+    try {
+      handle = await (item as DataTransferItem & {
+        getAsFileSystemHandle: () => Promise<FileSystemHandle | null>;
+      }).getAsFileSystemHandle();
+    } catch {
+      continue;
+    }
+
+    if (handle?.kind === 'directory') {
+      await openWorkspace(handle as FileSystemDirectoryHandle);
+      return;
+    }
+
+    if (handle?.kind === 'file') {
+      fileHandles.push(handle as FileSystemFileHandle);
+    }
+  }
+
+  if (fileHandles.length === 0) return;
+
+  prepareWorkspaceView(
+    fileHandles.length === 1
+      ? fileHandles[0].name
+      : Localization.translate('workspace_title')
+  );
+  rootDirHandle = null;
+  droppedFileHandles.clear();
+  directoryReadCache.clear();
+  sessionStorage.removeItem('workspace-active');
+  currentFileDir = '';
+
+  workspaceTree = fileHandles.map((fileHandle) => {
+    droppedFileHandles.set(fileHandle.name, fileHandle);
+    return {
+      name: fileHandle.name,
+      kind: 'file',
+      handle: fileHandle,
+      path: fileHandle.name,
+    };
+  });
+
+  const firstFile = workspaceTree[0];
+  activeFilePath = firstFile.path;
+  renderTreeView();
+  await openFile(firstFile.handle as FileSystemFileHandle);
+}
+
+let dragDepth = 0;
+
+function setDropOverlayVisible(visible: boolean): void {
+  $dropOverlay.classList.toggle('visible', visible);
+  $dropOverlay.setAttribute('aria-hidden', String(!visible));
+}
+
+window.addEventListener('dragenter', (event: DragEvent) => {
+  if (!event.dataTransfer?.types.includes('Files')) return;
+  event.preventDefault();
+  dragDepth += 1;
+  setDropOverlayVisible(true);
+});
+
+window.addEventListener('dragover', (event: DragEvent) => {
+  if (!event.dataTransfer?.types.includes('Files')) return;
+  event.preventDefault();
+  event.dataTransfer.dropEffect = 'copy';
+});
+
+window.addEventListener('dragleave', () => {
+  dragDepth = Math.max(0, dragDepth - 1);
+  if (dragDepth === 0) setDropOverlayVisible(false);
+});
+
+window.addEventListener('drop', (event: DragEvent) => {
+  if (!event.dataTransfer?.types.includes('Files')) return;
+  event.preventDefault();
+  dragDepth = 0;
+  setDropOverlayVisible(false);
+  void openDroppedItems(event.dataTransfer);
+});
 
 $pickBtn.addEventListener('click', pickAndOpen);
 $changeBtn.addEventListener('click', pickAndOpen);

--- a/firefox/src/popup/popup.ts
+++ b/firefox/src/popup/popup.ts
@@ -15,7 +15,5 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Firefox does not support workspace — hide the entry button
   const projectBtn = document.getElementById('open-project-btn');
-  if (projectBtn?.parentElement) {
-    projectBtn.parentElement.style.display = 'none';
-  }
+  if (projectBtn) projectBtn.style.display = 'none';
 });

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "build:chrome": "node chrome/build.js",
+    "dev:chrome": "node chrome/dev.js",
     "build:edge": "node edge/build.js",
     "build:firefox": "node firefox/build.js",
     "build:mobile": "node mobile/build.js",
@@ -80,6 +81,7 @@
     "eventemitter3": "^5.0.1",
     "file-type": "^20.5.0",
     "floating-vue": "^5.2.2",
+    "highlight.js": "^11.11.1",
     "katex": "^0.16.27",
     "markdown-it": "^14.1.1",
     "mathjax-full": "^3.2.2",

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -804,7 +804,7 @@
     "description": "Button to choose a directory"
   },
   "workspace_desc": {
-    "message": "Open a local directory to browse and preview supported files.",
+    "message": "Open a local directory or drop files and folders here to browse and preview supported files.",
     "description": "Description on the workspace landing page"
   },
   "workspace_open": {

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -804,7 +804,7 @@
     "description": "Button to open directory picker"
   },
   "workspace_desc": {
-    "message": "打开本地目录以浏览和预览支持的文件。",
+    "message": "打开本地目录，或将文件、文件夹拖到此处进行浏览和预览。",
     "description": "Workspace landing page description"
   },
   "workspace_open": {

--- a/src/_locales/zh_TW/messages.json
+++ b/src/_locales/zh_TW/messages.json
@@ -804,7 +804,7 @@
     "description": "Button to open directory picker"
   },
   "workspace_desc": {
-    "message": "開啟本機目錄以瀏覽和預覽支援的檔案。",
+    "message": "開啟本機目錄，或將檔案、資料夾拖放到此處進行瀏覽和預覽。",
     "description": "Workspace landing page description"
   },
   "workspace_open": {


### PR DESCRIPTION
## Summary

- add a `dev:chrome` workflow with watch mode, sourcemaps, and unminified development builds
- support dragging files and directories directly into the workspace
- show visual feedback while files are dragged over the workspace
- update workspace copy to communicate drag-and-drop support
- simplify the workspace entry in the popup
- refine recent-document hover styling

## Why

Chrome extension development previously required repeated production builds, and workspace files could only be opened through the directory picker. This adds a faster development loop and a more direct file-import experience without changing the production build behavior.

## Validation

- verified the Chrome production bundle
- verified `npm run dev:chrome` initial build and static-asset rebuild
- verified all 216 translation keys
- confirmed removed side-panel experiments are absent from the build output

## Notes

The repository-wide TypeScript check still reports existing errors in unrelated source and dependency files; the workspace drag-and-drop changes do not add new reported errors.
