### PR TITLE
Fix inline code pipes splitting GFM table cells

### DIFF
--- a/src/core/footnote-postprocessor.ts
+++ b/src/core/footnote-postprocessor.ts
@@ -1,5 +1,6 @@
 import type { Processor } from 'unified';
 import { normalizeMathBlocks, sanitizeRenderedHtml } from './markdown-processor';
+import { escapePipesInTableCodeSpans } from '../utils/markdown-table-code';
 import type { ParsedFootnotes, FootnoteDefinition } from './footnote-model.ts';
 
 function replaceReferenceTextNodes(container: HTMLElement, definitions: FootnoteDefinition[]): void {
@@ -62,7 +63,8 @@ function replaceReferenceTextNodes(container: HTMLElement, definitions: Footnote
 }
 
 async function renderFootnoteContent(content: string, processor: Processor): Promise<string> {
-  const file = await processor.process(normalizeMathBlocks(content));
+  const normalizedContent = escapePipesInTableCodeSpans(normalizeMathBlocks(content));
+  const file = await processor.process(normalizedContent);
   return sanitizeRenderedHtml(String(file));
 }
 

--- a/src/core/viewer/viewer-controller.ts
+++ b/src/core/viewer/viewer-controller.ts
@@ -18,6 +18,7 @@ import {
   normalizeMathBlocks,
   type HeadingInfo,
 } from '../markdown-processor';
+import { escapePipesInTableCodeSpans } from '../../utils/markdown-table-code';
 
 import {
   MarkdownDocument,
@@ -418,7 +419,7 @@ function normalizeHeadingIds(container: HTMLElement): void {
  * Render a single block's content to HTML
  */
 async function renderBlockContent(content: string, processor: Processor): Promise<string> {
-  const normalizedContent = normalizeMathBlocks(content);
+  const normalizedContent = escapePipesInTableCodeSpans(normalizeMathBlocks(content));
   const file = await processor.process(normalizedContent);
   let html = String(file);
   html = sanitizeRenderedHtml(html);

--- a/src/exporters/docx-exporter.ts
+++ b/src/exporters/docx-exporter.ts
@@ -37,6 +37,7 @@ import { loadThemeForDOCX } from './theme-to-docx';
 import { rewriteObsidianLinks } from '../utils/obsidian-link-rewrite';
 import type { FrontmatterDisplay } from '../ui/popup/settings-tab';
 import themeManager from '../utils/theme-manager';
+import { escapePipesInTableCodeSpans } from '../utils/markdown-table-code';
 import { getPluginForNode, convertNodeToDOCX } from '../plugins/index';
 import type { PluginRenderer } from '../types/plugin';
 import type { DocumentService } from '../types/platform';
@@ -491,7 +492,7 @@ class DocxExporter {
       .use(remarkSuperSub)
       .use(remarkGithubAlerts);  // GitHub-style alert syntax
 
-    const ast = processor.parse(footnoteAwareMarkdown);
+    const ast = processor.parse(escapePipesInTableCodeSpans(footnoteAwareMarkdown));
     const transformed = processor.runSync(ast);
 
     this.linkDefinitions = new Map();

--- a/src/utils/markdown-table-code.ts
+++ b/src/utils/markdown-table-code.ts
@@ -1,0 +1,114 @@
+function isTableDelimiterRow(line: string): boolean {
+  const indent = line.match(/^ */)?.[0].length ?? 0;
+  if (indent > 3) return false;
+
+  let value = line.trim();
+  if (!value.includes('|')) return false;
+  if (value.startsWith('|')) value = value.slice(1);
+  if (value.endsWith('|')) value = value.slice(0, -1);
+
+  const cells = value.split('|');
+  return cells.length > 0 && cells.every((cell) => /^:?-+:?$/.test(cell.trim()));
+}
+
+function isEscaped(value: string, index: number): boolean {
+  let backslashCount = 0;
+  for (let i = index - 1; i >= 0 && value[i] === '\\'; i--) {
+    backslashCount++;
+  }
+  return backslashCount % 2 === 1;
+}
+
+function escapeCodeSpanPipes(line: string): string {
+  let result = '';
+  let cursor = 0;
+
+  while (cursor < line.length) {
+    if (line[cursor] !== '`' || isEscaped(line, cursor)) {
+      result += line[cursor];
+      cursor++;
+      continue;
+    }
+
+    let delimiterLength = 1;
+    while (line[cursor + delimiterLength] === '`') {
+      delimiterLength++;
+    }
+
+    const delimiter = '`'.repeat(delimiterLength);
+    let closingIndex = line.indexOf(delimiter, cursor + delimiterLength);
+    while (
+      closingIndex !== -1 &&
+      (line[closingIndex - 1] === '`' || line[closingIndex + delimiterLength] === '`')
+    ) {
+      closingIndex = line.indexOf(delimiter, closingIndex + delimiterLength);
+    }
+
+    if (closingIndex === -1) {
+      result += line.slice(cursor);
+      break;
+    }
+
+    result += delimiter;
+    const content = line.slice(cursor + delimiterLength, closingIndex);
+    for (let i = 0; i < content.length; i++) {
+      if (content[i] === '|' && !isEscaped(content, i)) {
+        result += '\\';
+      }
+      result += content[i];
+    }
+    result += delimiter;
+    cursor = closingIndex + delimiterLength;
+  }
+
+  return result;
+}
+
+/**
+ * Preserve pipe characters inside inline code spans in GFM tables.
+ *
+ * remark-gfm treats unescaped pipes as table delimiters even when they are
+ * enclosed by backticks. Escaping only those pipes before parsing retains the
+ * intended cell structure, and remark removes the escape from inline-code text.
+ */
+export function escapePipesInTableCodeSpans(markdown: string): string {
+  const lines = markdown.split('\n');
+  const tableRows = new Set<number>();
+  let fence: { marker: string; length: number } | null = null;
+
+  for (let i = 0; i < lines.length; i++) {
+    const fenceMatch = lines[i].match(/^ {0,3}(`{3,}|~{3,})/);
+    if (fenceMatch) {
+      const marker = fenceMatch[1][0];
+      const length = fenceMatch[1].length;
+      if (!fence) {
+        fence = { marker, length };
+      } else if (
+        fence.marker === marker &&
+        length >= fence.length &&
+        lines[i].slice(fenceMatch[0].length).trim() === ''
+      ) {
+        fence = null;
+      }
+      continue;
+    }
+
+    if (fence || i === 0 || !isTableDelimiterRow(lines[i])) {
+      continue;
+    }
+
+    tableRows.add(i - 1);
+    for (let row = i + 1; row < lines.length && lines[row].trim() !== ''; row++) {
+      if (!lines[row].includes('|')) {
+        break;
+      }
+      tableRows.add(row);
+    }
+  }
+
+  for (const row of tableRows) {
+    lines[row] = escapeCodeSpanPipes(lines[row]);
+  }
+
+  return lines.join('\n');
+}

--- a/test/all.test.js
+++ b/test/all.test.js
@@ -10,3 +10,4 @@ import './remark-super-sub.test.js';
 import './remark-github-alerts.test.js';
 import './theme-alert-css.test.ts';
 import './remark-mode.test.ts';
+import './markdown-table-code.test.ts';

--- a/test/markdown-table-code.test.ts
+++ b/test/markdown-table-code.test.ts
@@ -1,0 +1,75 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+import { unified } from 'unified';
+import remarkGfm from 'remark-gfm';
+import remarkParse from 'remark-parse';
+
+import { escapePipesInTableCodeSpans } from '../src/utils/markdown-table-code.ts';
+
+describe('escapePipesInTableCodeSpans', () => {
+  it('escapes inline-code pipes in multi-column GFM tables', () => {
+    const markdown = [
+      '| Current condition | Duration | Longest interval |',
+      '|---|---:|---:|',
+      '| `|I| > 2 A` | 104.0 ms | 5.6 ms |',
+    ].join('\n');
+
+    assert.strictEqual(
+      escapePipesInTableCodeSpans(markdown),
+      [
+        '| Current condition | Duration | Longest interval |',
+        '|---|---:|---:|',
+        '| `\\|I\\| > 2 A` | 104.0 ms | 5.6 ms |',
+      ].join('\n')
+    );
+  });
+
+  it('produces the intended GFM table cells after parsing', () => {
+    const markdown = [
+      '| Current condition | Duration | Longest interval |',
+      '|---|---:|---:|',
+      '| `|I| > 2 A` | 104.0 ms | 5.6 ms |',
+    ].join('\n');
+    const processor = unified().use(remarkParse).use(remarkGfm);
+    const ast = processor.runSync(processor.parse(escapePipesInTableCodeSpans(markdown))) as {
+      children: Array<{
+        children: Array<{
+          children: Array<{ children: Array<{ type: string; value?: string }> }>;
+        }>;
+      }>;
+    };
+    const dataCells = ast.children[0].children[1].children;
+
+    assert.strictEqual(dataCells.length, 3);
+    assert.deepStrictEqual(
+      dataCells.map((cell) => cell.children[0]?.value),
+      ['|I| > 2 A', '104.0 ms', '5.6 ms']
+    );
+    assert.strictEqual(dataCells[0].children[0]?.type, 'inlineCode');
+  });
+
+  it('supports single-column tables and multi-backtick code spans', () => {
+    const markdown = ['| Expression |', '|---|', '| ``a`b|c`` |'].join('\n');
+    const expected = ['| Expression |', '|---|', '| ``a`b\\|c`` |'].join('\n');
+
+    assert.strictEqual(escapePipesInTableCodeSpans(markdown), expected);
+  });
+
+  it('does not double-escape existing table pipe escapes', () => {
+    const markdown = ['| Expression | Value |', '|---|---|', '| `a\\|b` | 1 |'].join('\n');
+
+    assert.strictEqual(escapePipesInTableCodeSpans(markdown), markdown);
+  });
+
+  it('leaves inline code outside tables unchanged', () => {
+    const markdown = 'Inline code outside a table: `a|b`.';
+
+    assert.strictEqual(escapePipesInTableCodeSpans(markdown), markdown);
+  });
+
+  it('ignores table-like content inside fenced code blocks', () => {
+    const markdown = ['```markdown', '| Expression |', '|---|', '| `a|b` |', '```'].join('\n');
+
+    assert.strictEqual(escapePipesInTableCodeSpans(markdown), markdown);
+  });
+});


### PR DESCRIPTION
## Summary

- preserve unescaped pipe characters inside inline code spans in GFM table cells
- apply the same preprocessing to viewer, footnote, and DOCX parsing paths
- add focused regression coverage for table parsing, existing escapes, multi-backtick spans, prose, and fenced code blocks

## Problem

`remark-gfm` treats pipes as table delimiters even when they appear inside backtick code spans. For example:

```markdown
| Current condition | Duration | Longest interval |
|---|---:|---:|
| `|I| > 2 A` | 104.0 ms | 5.6 ms |
```

The data row is split into extra cells, so both browser preview and DOCX export lose the intended column values.

## Implementation

The new preprocessor first identifies actual GFM table blocks, then escapes only unescaped pipes inside matched inline-code spans on those rows. It leaves prose, fenced code blocks, and already escaped pipes unchanged. `remark-gfm` removes the added escapes from the resulting inline-code values.

## Verification

- `node --test test/markdown-table-code.test.ts` (6 tests passed)
- `node chrome/build.js` (Chrome extension build passed)
- loaded the built unpacked extension in Chromium and opened a real report: the affected row rendered as exactly `|I| > 2 A`, `104.0 ms`, and `5.6 ms` in three cells, with no console errors
- `git diff --check`

The repository's aggregate Node test entry currently stops on existing extensionless TypeScript imports, and the existing typecheck baseline reports unrelated errors across the repository; neither failure reaches or points to this change.
