### PR TITLE
feat(obsidian): toggle the Markdown Viewer in place, from the view header

### DIFF
--- a/obsidian/src/host/main.ts
+++ b/obsidian/src/host/main.ts
@@ -5,10 +5,16 @@
  * Registers a custom ItemView for Markdown Viewer with DOCX export and settings.
  */
 
-import { Plugin, WorkspaceLeaf, TFile, MarkdownView, addIcon } from 'obsidian';
+import { Plugin, WorkspaceLeaf, TFile, MarkdownView, Menu, addIcon } from 'obsidian';
 import { MarkdownPreviewView, VIEW_TYPE, ViewerLeafState } from './preview-view';
 import { getFileType } from '../../../src/utils/file-wrapper';
 import { ALL_FORMAT_EXTENSIONS } from '../../../src/types/formats';
+
+/**
+ * Marks the header buttons we graft onto Obsidian's own markdown views.
+ * Those views outlive the plugin, so the buttons must be removed on unload.
+ */
+const TOGGLE_ACTION_ATTR = 'data-markdown-viewer-toggle';
 
 // Custom icon derived from icons/icon.svg (M letter, scaled to 100×100)
 const MARKDOWN_VIEWER_ICON = '<path fill="currentColor" d="M15.2 77.8v-55.7h13.9L50 43l20.9-20.9h13.9v55.7H70.9V41.9L50 62.7 29 42v36z"/>';
@@ -82,6 +88,23 @@ export default class MarkdownViewerPlugin extends Plugin {
       },
     });
 
+    // Toggle button in the markdown view's header, beside the reading-view
+    // toggle. Markdown leaves come and go, so re-sweep whenever layout changes.
+    this.app.workspace.onLayoutReady(() => this.addHeaderToggles());
+    this.registerEvent(
+      this.app.workspace.on('layout-change', () => this.addHeaderToggles())
+    );
+
+    // File explorer / link context menus. The tab's own menu is skipped —
+    // the header button already covers it.
+    this.registerEvent(
+      this.app.workspace.on('file-menu', (menu, file, source) => {
+        if (source !== 'more-options' && file instanceof TFile && isSupportedFile(file)) {
+          this.addMenuEntry(menu, file);
+        }
+      })
+    );
+
     // Update preview when active file changes
     this.registerEvent(
       this.app.workspace.on('active-leaf-change', () => {
@@ -100,7 +123,11 @@ export default class MarkdownViewerPlugin extends Plugin {
   }
 
   onunload() {
-    // Obsidian automatically cleans up registered views
+    // Registered views are cleaned up by Obsidian, but the header buttons live
+    // on its own markdown views and have to be taken back off by hand.
+    for (const button of Array.from(document.querySelectorAll(`[${TOGGLE_ACTION_ATTR}]`))) {
+      button.remove();
+    }
   }
 
   /**
@@ -145,6 +172,45 @@ export default class MarkdownViewerPlugin extends Plugin {
   }
 
   /**
+   * Give every markdown view a header button next to the built-in view-mode
+   * toggle. Idempotent — the marker attribute is both the "already done" test
+   * and the handle used to strip the buttons back off on unload.
+   */
+  private addHeaderToggles(): void {
+    for (const leaf of this.app.workspace.getLeavesOfType('markdown')) {
+      const view = leaf.view;
+      if (!(view instanceof MarkdownView)) continue;
+      if (view.containerEl.querySelector(`[${TOGGLE_ACTION_ATTR}]`)) continue;
+
+      const button = view.addAction('markdown-viewer', 'Open in Markdown Viewer', () => {
+        void this.toggleLeafView(leaf);
+      });
+      button.setAttribute(TOGGLE_ACTION_ATTR, '');
+    }
+  }
+
+  /**
+   * Context-menu entry for the file explorer and link menus: open the file in
+   * the viewer in a new tab.
+   */
+  private addMenuEntry(menu: Menu, file: TFile): void {
+    menu.addItem((item) => {
+      item
+        .setTitle('Open in Markdown Viewer')
+        .setIcon('markdown-viewer')
+        .setSection('open')
+        .onClick(async () => {
+          const leaf = this.app.workspace.getLeaf('tab');
+          await leaf.setViewState({
+            type: VIEW_TYPE,
+            active: true,
+            state: { file: file.path },
+          });
+        });
+    });
+  }
+
+  /**
    * Open the preview panel (or reveal if already open).
    */
   async showPreview(): Promise<void> {
@@ -170,8 +236,8 @@ export default class MarkdownViewerPlugin extends Plugin {
   /**
    * Push the current active file into the sidecar panel.
    *
-   * Only leaves that asked to follow are touched; a leaf that carries a file of
-   * its own owns it the same way a markdown tab does.
+   * Only leaves that asked to follow are touched; a tab toggled in place owns
+   * its file the same way a markdown tab does, and must not be hijacked.
    */
   updatePreviewContent(): void {
     const activeFile = this.app.workspace.getActiveFile();

--- a/obsidian/src/host/main.ts
+++ b/obsidian/src/host/main.ts
@@ -5,8 +5,8 @@
  * Registers a custom ItemView for Markdown Viewer with DOCX export and settings.
  */
 
-import { Plugin, WorkspaceLeaf, TFile, addIcon } from 'obsidian';
-import { MarkdownPreviewView, VIEW_TYPE } from './preview-view';
+import { Plugin, WorkspaceLeaf, TFile, MarkdownView, addIcon } from 'obsidian';
+import { MarkdownPreviewView, VIEW_TYPE, ViewerLeafState } from './preview-view';
 import { getFileType } from '../../../src/utils/file-wrapper';
 import { ALL_FORMAT_EXTENSIONS } from '../../../src/types/formats';
 
@@ -70,6 +70,18 @@ export default class MarkdownViewerPlugin extends Plugin {
       callback: () => this.showPreview(),
     });
 
+    // Command palette: swap the current tab in place, no second pane
+    this.addCommand({
+      id: 'toggle-view',
+      name: 'Toggle Markdown Viewer in current tab',
+      checkCallback: (checking) => {
+        const leaf = this.getToggleTarget();
+        if (!leaf) return false;
+        if (!checking) void this.toggleLeafView(leaf);
+        return true;
+      },
+    });
+
     // Update preview when active file changes
     this.registerEvent(
       this.app.workspace.on('active-leaf-change', () => {
@@ -89,6 +101,47 @@ export default class MarkdownViewerPlugin extends Plugin {
 
   onunload() {
     // Obsidian automatically cleans up registered views
+  }
+
+  /**
+   * The leaf a toggle would act on: the focused viewer, or the focused markdown
+   * editor holding a file this plugin can render.
+   */
+  private getToggleTarget(): WorkspaceLeaf | null {
+    const viewer = this.app.workspace.getActiveViewOfType(MarkdownPreviewView);
+    if (viewer) return viewer.leaf;
+
+    const markdown = this.app.workspace.getActiveViewOfType(MarkdownView);
+    if (markdown?.file && isSupportedFile(markdown.file)) return markdown.leaf;
+
+    return null;
+  }
+
+  /**
+   * Swap a leaf between the built-in markdown view and the viewer, in place.
+   *
+   * The leaf's own view state carries the file, so both directions are one
+   * operation with the type swapped — there is no second pane to keep in sync.
+   */
+  async toggleLeafView(leaf: WorkspaceLeaf): Promise<void> {
+    const current = leaf.getViewState();
+    const state = (current.state ?? {}) as ViewerLeafState;
+    if (!state.file) return;
+
+    if (current.type === VIEW_TYPE) {
+      await leaf.setViewState({
+        type: 'markdown',
+        active: true,
+        state: { ...state.prev, file: state.file },
+      });
+      return;
+    }
+
+    await leaf.setViewState({
+      type: VIEW_TYPE,
+      active: true,
+      state: { file: state.file, prev: current.state },
+    });
   }
 
   /**

--- a/obsidian/src/host/main.ts
+++ b/obsidian/src/host/main.ts
@@ -95,20 +95,30 @@ export default class MarkdownViewerPlugin extends Plugin {
    * Open the preview panel (or reveal if already open).
    */
   async showPreview(): Promise<void> {
-    const existing = this.app.workspace.getLeavesOfType(VIEW_TYPE);
-    if (existing.length > 0) {
-      this.app.workspace.revealLeaf(existing[0]);
+    const existing = this.app.workspace
+      .getLeavesOfType(VIEW_TYPE)
+      .find((leaf) => leaf.view instanceof MarkdownPreviewView && leaf.view.followsActiveFile());
+
+    if (existing) {
+      this.app.workspace.revealLeaf(existing);
       this.updatePreviewContent();
       return;
     }
 
     const leaf = this.app.workspace.getLeaf('split');
-    await leaf.setViewState({ type: VIEW_TYPE, active: true });
+    await leaf.setViewState({
+      type: VIEW_TYPE,
+      active: true,
+      state: { file: this.app.workspace.getActiveFile()?.path, follow: true },
+    });
     this.app.workspace.revealLeaf(leaf);
   }
 
   /**
-   * Push the current active markdown file content to all preview views.
+   * Push the current active file into the sidecar panel.
+   *
+   * Only leaves that asked to follow are touched; a leaf that carries a file of
+   * its own owns it the same way a markdown tab does.
    */
   updatePreviewContent(): void {
     const activeFile = this.app.workspace.getActiveFile();
@@ -116,7 +126,7 @@ export default class MarkdownViewerPlugin extends Plugin {
 
     for (const leaf of this.app.workspace.getLeavesOfType(VIEW_TYPE)) {
       const view = leaf.view;
-      if (view instanceof MarkdownPreviewView) {
+      if (view instanceof MarkdownPreviewView && view.followsActiveFile()) {
         view.setFile(activeFile);
       }
     }

--- a/obsidian/src/host/preview-view.ts
+++ b/obsidian/src/host/preview-view.ts
@@ -23,10 +23,16 @@ import { ServiceChannel } from '../../../src/messaging/channels/service-channel'
 
 export const VIEW_TYPE = 'markdown-viewer-preview';
 
-/** What a leaf carries for this view. */
+/**
+ * What a leaf carries for this view.
+ *
+ * `prev` is whatever state the leaf held before this view took it over, kept
+ * opaque: restoring it is this plugin's job, understanding it is not.
+ */
 export interface ViewerLeafState {
   file?: string;
   follow?: boolean;
+  prev?: Record<string, unknown>;
 }
 
 export class MarkdownPreviewView extends ItemView {
@@ -36,6 +42,8 @@ export class MarkdownPreviewView extends ItemView {
 
   /** True for the sidecar panel, which mirrors whatever file is active. */
   private followActiveFile = false;
+  /** The leaf's previous state, parked here while this view owns the leaf. */
+  private prevViewState: Record<string, unknown> | undefined;
 
   private hostChannel: ServiceChannel | null = null;
   private isViewerReady = false;
@@ -65,6 +73,10 @@ export class MarkdownPreviewView extends ItemView {
 
     this.addAction('download', 'Export', () => {
       this.openExportMenu();
+    });
+
+    this.addAction('pencil', 'Edit as markdown', () => {
+      void this.plugin.toggleLeafView(this.leaf);
     });
   }
 
@@ -96,6 +108,7 @@ export class MarkdownPreviewView extends ItemView {
       ...super.getState(),
       file: this.currentFile?.path,
       follow: this.followActiveFile,
+      prev: this.prevViewState,
     };
   }
 
@@ -103,6 +116,7 @@ export class MarkdownPreviewView extends ItemView {
     const incoming = (state ?? {}) as ViewerLeafState;
 
     this.followActiveFile = incoming.follow ?? typeof incoming.file !== 'string';
+    this.prevViewState = incoming.prev;
 
     if (incoming.file && incoming.file !== this.currentFile?.path) {
       const file = this.app.vault.getAbstractFileByPath(incoming.file);

--- a/obsidian/src/host/preview-view.ts
+++ b/obsidian/src/host/preview-view.ts
@@ -8,7 +8,7 @@
  * Provides title-bar action buttons for export and settings.
  */
 
-import { ItemView, WorkspaceLeaf, TFile, Menu, Notice } from 'obsidian';
+import { ItemView, WorkspaceLeaf, TFile, Menu, Notice, ViewStateResult } from 'obsidian';
 import type MarkdownViewerPlugin from './main';
 import { getFileType } from '../../../src/utils/file-wrapper';
 import { rewriteObsidianSvgEmbeds } from './obsidian-svg-embed-rewrite';
@@ -23,10 +23,20 @@ import { ServiceChannel } from '../../../src/messaging/channels/service-channel'
 
 export const VIEW_TYPE = 'markdown-viewer-preview';
 
+/** What a leaf carries for this view. */
+export interface ViewerLeafState {
+  file?: string;
+  follow?: boolean;
+}
+
 export class MarkdownPreviewView extends ItemView {
   private plugin: MarkdownViewerPlugin;
   private currentFile: TFile | null = null;
   private openedDocumentPath: string | null = null;
+
+  /** True for the sidecar panel, which mirrors whatever file is active. */
+  private followActiveFile = false;
+
   private hostChannel: ServiceChannel | null = null;
   private isViewerReady = false;
   private pendingMessages: Array<{ type: string; payload?: unknown }> = [];
@@ -73,6 +83,42 @@ export class MarkdownPreviewView extends ItemView {
   }
 
   // ===========================================================================
+  // View state
+  //
+  // Persisting the file on the leaf is what lets a preview survive a workspace
+  // reload and lets Obsidian open a registered extension straight into this
+  // view. A leaf carrying no file of its own can only be the sidecar panel, so
+  // that is the default for states saved before this existed.
+  // ===========================================================================
+
+  getState(): Record<string, unknown> {
+    return {
+      ...super.getState(),
+      file: this.currentFile?.path,
+      follow: this.followActiveFile,
+    };
+  }
+
+  async setState(state: unknown, result: ViewStateResult): Promise<void> {
+    const incoming = (state ?? {}) as ViewerLeafState;
+
+    this.followActiveFile = incoming.follow ?? typeof incoming.file !== 'string';
+
+    if (incoming.file && incoming.file !== this.currentFile?.path) {
+      const file = this.app.vault.getAbstractFileByPath(incoming.file);
+      if (file instanceof TFile) {
+        await this.setFile(file);
+      }
+    }
+
+    await super.setState(state, result);
+  }
+
+  followsActiveFile(): boolean {
+    return this.followActiveFile;
+  }
+
+  // ===========================================================================
   // Lifecycle
   // ===========================================================================
 
@@ -107,10 +153,13 @@ export class MarkdownPreviewView extends ItemView {
     // Initialize the viewer directly in the container (no iframe)
     await initializeViewer(container);
 
-    // Load current active file
-    const activeFile = this.app.workspace.getActiveFile();
-    if (activeFile && isSupportedFile(activeFile)) {
-      await this.setFile(activeFile);
+    // Fall back to the active file only when the leaf brought no file of its
+    // own — setState has already run for a restored or extension-opened leaf.
+    if (!this.currentFile) {
+      const activeFile = this.app.workspace.getActiveFile();
+      if (activeFile && isSupportedFile(activeFile)) {
+        await this.setFile(activeFile);
+      }
     }
   }
 


### PR DESCRIPTION
## What

Lets a markdown tab be switched into the Markdown Viewer **in place**, instead of only being able to open a second pane beside it.

Obsidian's own edit/reading switch lives in the view header, so the toggle goes in that same row rather than into a menu. The existing sidecar panel (ribbon icon + `Open Markdown Viewer` command) is unchanged.

## Why

Reaching the viewer meant opening a split panel that then chased the active file. That asked the user to maintain a pairing between two panes, and the pairing had to be re-synced on every `active-leaf-change`.

The underlying reason it worked that way: **`MarkdownPreviewView` implemented neither `getState` nor `setState`**, so a leaf carried no record of what it was showing. The view guessed instead, reading `workspace.getActiveFile()` in `onOpen`. Two things fell out of that guess:

- a preview restored from `workspace.json` came back empty — the guess runs against whatever file happens to be active at startup, not the one the tab was showing
- opening a registered extension (`.drawio`, `.canvas`, ...) worked by accident rather than because Obsidian handed the file to the view

Once the file lives on the leaf, the two view types become interchangeable on one leaf: swap the type and the file rides along. The in-place toggle is then a consequence of the state fix, not a feature bolted on top of it.

## Commits

Three, in dependency order — each builds and typechecks on its own:

1. **`fix(obsidian): keep the previewed file on the leaf's view state`** — the state fix. Stands alone as a bugfix for the empty-preview-after-restart problem, independent of anything below it.
2. **`feat(obsidian): toggle the viewer in place instead of opening a second pane`** — `toggleLeafView` + a `Toggle Markdown Viewer in current tab` command + an "Edit as markdown" action in the viewer's header.
3. **`feat(obsidian): put the toggle in the markdown header and file menu`** — the entry points. Revert this one and the command-palette path still works.

## Notes on the approach

**Sidecar vs. owned tab.** A leaf that carries a file owns it, like a markdown tab does; only a leaf that asked to follow gets re-pointed at the active file. Without that distinction `updatePreviewContent` would hijack an in-place tab whenever the user clicked a different one. States saved before this change carry no file — exactly the sidecar case — so they default to following and need no migration.

**Previous state is kept opaque.** When the viewer takes over a leaf, the leaf's prior state is stored wholesale under `prev` and spread back on the way out. `MarkdownPreviewView` never declares it understands `mode` or `source`; those belong to the built-in editor, and restoring them is this plugin's job while interpreting them is not.

**Header buttons.** `addAction` is `@public` on `ItemView`, which `MarkdownView` inherits, so the button lands in the real action row rather than being injected into the DOM by hand. Markdown leaves come and go, so buttons are swept on `layout-change`; the marker attribute serves as both the "already decorated" test and the handle for removing them in `onunload` — necessary because the buttons live on Obsidian's own views, which outlive the plugin.

The tab's own more-options menu is deliberately left alone: the header button already sits right there. The file explorer and link menus do get an entry, opening a new tab straight into the viewer.

## Testing

Built with `npm run build:obsidian` and exercised by hand in Obsidian: toggling a tab both directions, editor mode surviving a round trip, two viewer tabs not clobbering each other's content, and a toggled tab coming back correctly after `Reload app without saving`.

No automated tests were added — the host layer has no Obsidian test harness in this repo, and standing one up is well outside this change.

## Follow-ups, deliberately not in this PR

Each of these is real but has its own review surface, and folding any of them in here would turn a focused change into a sweep:

1. **`obsidian/` is not typechecked at all.** `tsconfig.json`'s `include` covers `src`, `chrome/src`, `firefox/src`, `vscode/src`, `mobile/src` — not `obsidian/src`. `obsidian` is also not a devDependency, so there are no typings for it. Adding the directory surfaces ~44 pre-existing errors (`settings-tab.ts` 6, `webview/main.ts` 3, `preview-view.ts` 2). I verified this PR against a temporary tsconfig that does include `obsidian/`; the commits add zero new type errors, and neither `tsconfig.json` nor `package.json` is touched here.

2. **`obsidian/src/host/settings-tab.ts` is dead code.** Nothing imports it, `addSettingTab` is never called, and the string `Auto-preview on file open` does not appear in the built `main.js`. The `autoPreviewOnOpen` setting it defines does not exist at runtime. This is downstream of (1) — with the directory unchecked, nothing flagged it.

3. **Possible double read on the `READY` path.** `postToViewer` queues when the viewer is not ready, and the `READY` handler flushes `pendingMessages` and *then* unconditionally calls `sendFileContent` again. When a file arrives via `setState` before `READY`, that looks like it re-reads the file and re-runs embed expansion a second time. I did not touch it: it is pre-existing code, and confirming it needs certainty about whether `onOpen` runs before or after `setState`, which I could not establish from the outside.
