### PR TITLE
feat: add headless Chrome HTML CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,30 @@ It is built for technical documentation, engineering notes, research drafts, wee
 - **VS Code:** https://marketplace.visualstudio.com/items?itemName=xicilion.markdown-viewer-extension · https://open-vsx.org/extension/xicilion/markdown-viewer-extension
 - **Mobile:** See the [mobile app docs](https://github.com/markdown-viewer/docs/blob/main/platforms/mobile.md)
 
+## Node.js HTML CLI
+
+The repository includes a headless-Chrome CLI that renders a Markdown file with
+the same parser, themes, math support, and diagram renderers used by the viewer.
+It requires Node.js 24 or newer and an installed Google Chrome browser.
+
+```bash
+npm install
+npm run build:cli
+npm run md-to-html -- README.md --output README.html
+```
+
+Chrome runs headlessly and uses a temporary browser profile. A separate Chromium
+download is not required. Common options include:
+
+```bash
+npm run md-to-html -- notes.md --theme technical
+npm run md-to-html -- report.md --frontmatter table --merge-empty-cells
+npm run md-to-html -- night.md --theme midnight --output night.html
+```
+
+Run `npm run md-to-html -- --help` for all options. Theme IDs are listed in
+`src/themes/registry.json`.
+
 ## Highlights
 
 - Clean Markdown preview for local files and supported web URLs.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "version": "5.2.1",
   "description": "Open Markdown files in the browser and export polished Word documents with diagrams, editable math, code highlighting, and local processing.",
   "type": "module",
+  "bin": {
+    "documd": "scripts/md-to-html.js"
+  },
   "scripts": {
     "build:chrome": "node chrome/build.js",
     "dev:chrome": "node chrome/dev.js",
@@ -14,6 +17,8 @@
     "build:slidev": "npx vite build --config slidev-shell/vite.vscode.config.ts",
     "build:vscode": "node vscode/build.js",
     "build:obsidian": "node obsidian/build.js",
+    "build:cli": "node scripts/build-cli.js",
+    "md-to-html": "node scripts/md-to-html.js",
     "sync:formats": "node scripts/sync-formats.js",
     "build:app": "node mobile/build-app.js all",
     "build:ios": "node mobile/build-app.js ios",
@@ -104,6 +109,7 @@
     "material-icon-theme": "^5.33.1",
     "mathjax-full": "^3.2.2",
     "mermaid": "^11.12.2",
+    "playwright-core": "^1.62.1",
     "rehype-highlight": "^7.0.2",
     "rehype-katex": "^7.0.1",
     "rehype-slug": "^6.0.0",

--- a/scripts/build-cli.js
+++ b/scripts/build-cli.js
@@ -1,0 +1,70 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { build } from 'esbuild';
+import { dagreShimPlugin } from './dagre-shim-plugin.js';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(scriptDir, '..');
+const outputDir = path.join(projectRoot, 'dist', 'cli');
+
+await fs.rm(outputDir, { recursive: true, force: true });
+await fs.mkdir(outputDir, { recursive: true });
+
+await build({
+  entryPoints: [path.join(projectRoot, 'src', 'cli', 'browser-renderer.ts')],
+  outfile: path.join(outputDir, 'browser-renderer.js'),
+  bundle: true,
+  format: 'iife',
+  platform: 'browser',
+  target: ['chrome120'],
+  treeShaking: true,
+  minify: true,
+  define: {
+    'process.env.NODE_ENV': '"production"',
+    MV_PLATFORM: '"cli"',
+    MV_RUNTIME: '"worker"',
+    global: 'globalThis',
+  },
+  inject: [path.join(projectRoot, 'scripts', 'buffer-shim.js')],
+  loader: {
+    '.css': 'css',
+    '.woff': 'dataurl',
+    '.woff2': 'dataurl',
+    '.ttf': 'dataurl',
+  },
+  external: ['web-worker'],
+  plugins: [dagreShimPlugin],
+});
+
+await build({
+  entryPoints: [path.join(projectRoot, 'src', 'ui', 'styles.css')],
+  outfile: path.join(outputDir, 'styles.css'),
+  bundle: true,
+  minify: true,
+  loader: {
+    '.woff': 'dataurl',
+    '.woff2': 'dataurl',
+    '.ttf': 'dataurl',
+    '.eot': 'dataurl',
+  },
+});
+
+await fs.cp(path.join(projectRoot, 'src', 'themes'), path.join(outputDir, 'themes'), { recursive: true });
+
+const stencilSource = path.join(
+  projectRoot,
+  'node_modules',
+  '@markdown-viewer',
+  'drawio2svg',
+  'resources',
+  'stencils',
+);
+try {
+  await fs.cp(stencilSource, path.join(outputDir, 'stencils'), { recursive: true });
+} catch (error) {
+  if (error?.code !== 'ENOENT') throw error;
+}
+
+console.log(`CLI browser assets built in ${path.relative(projectRoot, outputDir)}`);

--- a/scripts/md-to-html.js
+++ b/scripts/md-to-html.js
@@ -1,0 +1,357 @@
+#!/usr/bin/env node
+
+import crypto from 'node:crypto';
+import fs from 'node:fs/promises';
+import http from 'node:http';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+import { chromium } from 'playwright-core';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(scriptDir, '..');
+const cliAssetDir = path.join(projectRoot, 'dist', 'cli');
+
+const HELP = `documd - render Markdown to a standalone HTML file with headless Chrome
+
+Usage:
+  documd <input.md> [options]
+
+Options:
+  -o, --output <file>       Output path (default: input name with .html)
+  -t, --theme <id>          Viewer theme (default: default)
+      --title <text>        Override the HTML document title
+      --language <code>     HTML language code (default: en)
+      --frontmatter <mode>  hide, table, or raw (default: hide)
+      --table-layout <mode> left, center, or center-full-width
+      --merge-empty-cells   Merge empty Markdown table cells
+      --chrome <path>       Explicit Chrome executable path
+      --timeout <seconds>   Overall render timeout (default: 120)
+  -h, --help                Show this help
+`;
+
+function takeValue(args, index, option) {
+  const value = args[index + 1];
+  if (!value || value.startsWith('-')) throw new Error(`${option} requires a value`);
+  return value;
+}
+
+export function parseArgs(args) {
+  const options = {
+    theme: 'default',
+    language: 'en',
+    frontmatterDisplay: 'hide',
+    tableLayout: 'center',
+    tableMergeEmpty: false,
+    timeoutMs: 120_000,
+  };
+  const positional = [];
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === '-h' || arg === '--help') {
+      options.help = true;
+    } else if (arg === '-o' || arg === '--output') {
+      options.output = takeValue(args, i, arg);
+      i += 1;
+    } else if (arg === '-t' || arg === '--theme') {
+      options.theme = takeValue(args, i, arg);
+      i += 1;
+    } else if (arg === '--title') {
+      options.title = takeValue(args, i, arg);
+      i += 1;
+    } else if (arg === '--language') {
+      options.language = takeValue(args, i, arg);
+      i += 1;
+    } else if (arg === '--frontmatter') {
+      options.frontmatterDisplay = takeValue(args, i, arg);
+      i += 1;
+    } else if (arg === '--table-layout') {
+      options.tableLayout = takeValue(args, i, arg);
+      i += 1;
+    } else if (arg === '--merge-empty-cells') {
+      options.tableMergeEmpty = true;
+    } else if (arg === '--chrome') {
+      options.chromePath = takeValue(args, i, arg);
+      i += 1;
+    } else if (arg === '--timeout') {
+      const seconds = Number(takeValue(args, i, arg));
+      if (!Number.isFinite(seconds) || seconds <= 0) {
+        throw new Error('--timeout must be a positive number of seconds');
+      }
+      options.timeoutMs = seconds * 1000;
+      i += 1;
+    } else if (arg.startsWith('-')) {
+      throw new Error(`Unknown option: ${arg}`);
+    } else {
+      positional.push(arg);
+    }
+  }
+
+  if (!options.help && positional.length !== 1) {
+    throw new Error('Exactly one input Markdown file is required');
+  }
+  if (!['hide', 'table', 'raw'].includes(options.frontmatterDisplay)) {
+    throw new Error('--frontmatter must be hide, table, or raw');
+  }
+  if (!['left', 'center', 'center-full-width'].includes(options.tableLayout)) {
+    throw new Error('--table-layout must be left, center, or center-full-width');
+  }
+
+  options.input = positional[0];
+  return options;
+}
+
+function outputPathFor(inputPath, requestedOutput) {
+  if (requestedOutput) return path.resolve(requestedOutput);
+  const parsed = path.parse(inputPath);
+  return path.join(parsed.dir, `${parsed.name}.html`);
+}
+
+function mimeType(filePath) {
+  const extension = path.extname(filePath).toLowerCase();
+  return {
+    '.css': 'text/css; charset=utf-8',
+    '.gif': 'image/gif',
+    '.html': 'text/html; charset=utf-8',
+    '.jpeg': 'image/jpeg',
+    '.jpg': 'image/jpeg',
+    '.js': 'text/javascript; charset=utf-8',
+    '.json': 'application/json; charset=utf-8',
+    '.png': 'image/png',
+    '.svg': 'image/svg+xml; charset=utf-8',
+    '.webp': 'image/webp',
+    '.woff': 'font/woff',
+    '.woff2': 'font/woff2',
+  }[extension] || 'application/octet-stream';
+}
+
+function isWithin(root, candidate) {
+  const relative = path.relative(root, candidate);
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+async function sendFile(response, filePath) {
+  try {
+    const data = await fs.readFile(filePath);
+    response.writeHead(200, {
+      'content-type': mimeType(filePath),
+      'cache-control': 'no-store',
+    });
+    response.end(data);
+  } catch (error) {
+    response.writeHead(error?.code === 'ENOENT' ? 404 : 500);
+    response.end(error?.code === 'ENOENT' ? 'Not found' : 'Unable to read file');
+  }
+}
+
+function rendererHtml(basePath) {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" href="data:,">
+  <link rel="stylesheet" href="${basePath}/styles.css">
+</head>
+<body>
+  <div id="markdown-page"><main id="markdown-content"></main></div>
+  <script src="${basePath}/browser-renderer.js"></script>
+</body>
+</html>`;
+}
+
+function virtualDocumentDirectory(documentDir) {
+  const normalized = documentDir.replace(/\\/g, '/');
+  if (normalized.startsWith('/')) return `__root__${normalized}`;
+  return normalized;
+}
+
+function localPathFromVirtual(value) {
+  if (value.startsWith('__root__/')) return `/${value.slice('__root__/'.length)}`;
+  return value.replace(/\//g, path.sep);
+}
+
+async function startAssetServer(documentDir) {
+  const token = crypto.randomBytes(18).toString('hex');
+  const basePath = `/__documd/${token}`;
+  const virtualDirectory = virtualDocumentDirectory(documentDir);
+  const rendererPath = `${basePath}/fs/${virtualDirectory}/__documd_renderer__.html`;
+
+  const server = http.createServer(async (request, response) => {
+    try {
+      const url = new URL(request.url || '/', 'http://127.0.0.1');
+      const decodedPathname = decodeURIComponent(url.pathname);
+      if (decodedPathname === rendererPath) {
+        response.writeHead(200, {
+          'content-type': 'text/html; charset=utf-8',
+          'cache-control': 'no-store',
+        });
+        response.end(rendererHtml(basePath));
+        return;
+      }
+
+      if (url.pathname === `${basePath}/file`) {
+        const requestedPath = url.searchParams.get('path');
+        if (!requestedPath) {
+          response.writeHead(400).end('Missing path');
+          return;
+        }
+        let localPath = requestedPath;
+        if (localPath.toLowerCase().startsWith('file:')) {
+          localPath = fileURLToPath(localPath);
+        } else if (!path.isAbsolute(localPath)) {
+          localPath = path.resolve(documentDir, localPath);
+        }
+        await sendFile(response, localPath);
+        return;
+      }
+
+      if (url.pathname.startsWith(`${basePath}/document/`)) {
+        const relativePath = decodeURIComponent(url.pathname.slice(`${basePath}/document/`.length));
+        const localPath = path.resolve(documentDir, relativePath);
+        if (!isWithin(documentDir, localPath)) {
+          response.writeHead(403).end('Outside document directory');
+          return;
+        }
+        await sendFile(response, localPath);
+        return;
+      }
+
+      if (decodedPathname.startsWith(`${basePath}/fs/`)) {
+        const virtualPath = decodedPathname.slice(`${basePath}/fs/`.length);
+        await sendFile(response, localPathFromVirtual(virtualPath));
+        return;
+      }
+
+      const assetPrefix = `${basePath}/`;
+      if (url.pathname.startsWith(assetPrefix)) {
+        const relativePath = decodeURIComponent(url.pathname.slice(assetPrefix.length));
+        const localPath = path.resolve(cliAssetDir, relativePath);
+        if (!isWithin(cliAssetDir, localPath)) {
+          response.writeHead(403).end('Outside asset directory');
+          return;
+        }
+        await sendFile(response, localPath);
+        return;
+      }
+
+      response.writeHead(404).end('Not found');
+    } catch {
+      response.writeHead(500).end('Internal server error');
+    }
+  });
+
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    server.close();
+    throw new Error('Unable to determine renderer server address');
+  }
+
+  const origin = `http://127.0.0.1:${address.port}`;
+  return {
+    pageUrl: `${origin}${rendererPath}`,
+    documentBaseUrl: `${origin}${basePath}/fs/${virtualDirectory}`,
+    fileReadUrl: `${origin}${basePath}/file`,
+    resourceBaseUrl: `${origin}${basePath}/`,
+    close: () => new Promise((resolve) => server.close(resolve)),
+  };
+}
+
+async function withTimeout(promise, timeoutMs) {
+  let timeout;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((_, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error(`Render timed out after ${timeoutMs / 1000} seconds`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function renderMarkdownFile(options) {
+  const inputPath = path.resolve(options.input);
+  const outputPath = outputPathFor(inputPath, options.output);
+  const markdown = await fs.readFile(inputPath, 'utf8');
+
+  await fs.access(path.join(cliAssetDir, 'browser-renderer.js')).catch(() => {
+    throw new Error('CLI browser assets are missing. Run "npm run build:cli" first.');
+  });
+
+  const server = await startAssetServer(path.dirname(inputPath));
+  let browser;
+  try {
+    browser = await chromium.launch({
+      headless: true,
+      ...(options.chromePath
+        ? { executablePath: path.resolve(options.chromePath) }
+        : { channel: 'chrome' }),
+    });
+
+    const page = await browser.newPage({ viewport: { width: 1440, height: 1000 } });
+    const browserErrors = [];
+    page.on('console', (message) => {
+      if (message.type() === 'error') browserErrors.push(message.text());
+    });
+    page.on('pageerror', (error) => browserErrors.push(error.message));
+
+    await page.goto(server.pageUrl, { waitUntil: 'load' });
+    await page.waitForFunction(() => typeof window.markdownCli?.render === 'function');
+
+    const html = await withTimeout(page.evaluate((request) => {
+      return window.markdownCli.render(request);
+    }, {
+      markdown,
+      filename: path.basename(inputPath),
+      title: options.title,
+      theme: options.theme,
+      language: options.language,
+      frontmatterDisplay: options.frontmatterDisplay,
+      tableMergeEmpty: options.tableMergeEmpty,
+      tableLayout: options.tableLayout,
+      documentPath: inputPath,
+      documentDir: path.dirname(inputPath),
+      documentBaseUrl: server.documentBaseUrl,
+      fileReadUrl: server.fileReadUrl,
+      resourceBaseUrl: server.resourceBaseUrl,
+    }), options.timeoutMs);
+
+    await fs.mkdir(path.dirname(outputPath), { recursive: true });
+    await fs.writeFile(outputPath, html, 'utf8');
+    return { outputPath, browserErrors };
+  } finally {
+    await browser?.close();
+    await server.close();
+  }
+}
+
+async function main() {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    if (options.help) {
+      process.stdout.write(HELP);
+      return;
+    }
+    const result = await renderMarkdownFile(options);
+    for (const warning of result.browserErrors) console.warn(`[browser] ${warning}`);
+    console.log(`Rendered ${result.outputPath}`);
+  } catch (error) {
+    console.error(`documd: ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  }
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : '';
+if (invokedPath === fileURLToPath(import.meta.url)) await main();

--- a/scripts/md-to-html.js
+++ b/scripts/md-to-html.js
@@ -109,6 +109,19 @@ function outputPathFor(inputPath, requestedOutput) {
   return path.join(parsed.dir, `${parsed.name}.html`);
 }
 
+export async function ensureOutputDirectory(outputPath) {
+  const outputDirectory = path.dirname(outputPath);
+  try {
+    const stats = await fs.stat(outputDirectory);
+    if (!stats.isDirectory()) {
+      throw new Error(`Output parent is not a directory: ${outputDirectory}`);
+    }
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error;
+    await fs.mkdir(outputDirectory, { recursive: true });
+  }
+}
+
 function mimeType(filePath) {
   const extension = path.extname(filePath).toLowerCase();
   return {
@@ -328,7 +341,7 @@ export async function renderMarkdownFile(options) {
       resourceBaseUrl: server.resourceBaseUrl,
     }), options.timeoutMs);
 
-    await fs.mkdir(path.dirname(outputPath), { recursive: true });
+    await ensureOutputDirectory(outputPath);
     await fs.writeFile(outputPath, html, 'utf8');
     return { outputPath, browserErrors };
   } finally {

--- a/src/cli/browser-renderer.ts
+++ b/src/cli/browser-renderer.ts
@@ -1,0 +1,188 @@
+import mermaid from 'mermaid';
+
+import { exportToHtml } from '../exporters/html-exporter';
+import { renderMarkdownDocument, resetDocument } from '../core/viewer/viewer-controller';
+import { handleRender, initRenderEnvironment } from '../renderers/render-worker-core';
+import { loadAndApplyTheme } from '../utils/theme-to-css';
+import type { DocumentService, PlatformAPI } from '../types/platform';
+import type { RendererThemeConfig } from '../types/render';
+
+type FrontmatterDisplay = 'hide' | 'table' | 'raw';
+
+export interface CliBrowserRenderRequest {
+  markdown: string;
+  filename: string;
+  title?: string;
+  theme?: string;
+  language?: string;
+  frontmatterDisplay?: FrontmatterDisplay;
+  tableMergeEmpty?: boolean;
+  tableLayout?: 'left' | 'center' | 'center-full-width';
+  documentPath: string;
+  documentDir: string;
+  documentBaseUrl: string;
+  fileReadUrl: string;
+  resourceBaseUrl: string;
+}
+
+type CliBrowserApi = {
+  render(request: CliBrowserRenderRequest): Promise<string>;
+};
+
+declare global {
+  interface Window {
+    markdownCli: CliBrowserApi;
+    mermaid: typeof mermaid;
+  }
+}
+
+window.mermaid = mermaid;
+initRenderEnvironment();
+
+let rendererThemeConfig: RendererThemeConfig | null = null;
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = '';
+  const chunkSize = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
+  }
+  return btoa(binary);
+}
+
+function normalizeRelativePath(value: string): string {
+  return value.replace(/\\/g, '/').replace(/^\.\//, '');
+}
+
+function createDocumentService(request: CliBrowserRenderRequest): DocumentService {
+  const readResponse = async (url: string, binary = false): Promise<string> => {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Unable to read resource (${response.status}): ${url}`);
+    }
+    if (!binary) return response.text();
+    return bytesToBase64(new Uint8Array(await response.arrayBuffer()));
+  };
+
+  const relativeUrl = (relativePath: string): string => {
+    const normalized = normalizeRelativePath(relativePath);
+    return new URL(normalized, `${request.documentBaseUrl}/`).href;
+  };
+
+  return {
+    documentPath: request.documentPath,
+    documentDir: request.documentDir,
+    baseUrl: request.documentBaseUrl,
+    needsUriRewrite: false,
+    readFile: async (filePath, options) => {
+      if (!/^(?:file:|[a-zA-Z]:[\\/]|\/)/.test(filePath)) {
+        return readResponse(relativeUrl(filePath), options?.binary);
+      }
+      const url = new URL(request.fileReadUrl);
+      url.searchParams.set('path', filePath);
+      return readResponse(url.href, options?.binary);
+    },
+    readRelativeFile: (relativePath, options) => readResponse(relativeUrl(relativePath), options?.binary),
+    resolvePath: (relativePath) => normalizeRelativePath(relativePath),
+    toResourceUrl: (filePath) => {
+      if (/^(?:file:|[a-zA-Z]:[\\/]|\/)/.test(filePath)) {
+        const url = new URL(request.fileReadUrl);
+        url.searchParams.set('path', filePath);
+        return url.href;
+      }
+      return relativeUrl(filePath);
+    },
+    setDocumentPath: () => {},
+  };
+}
+
+function configurePlatform(request: CliBrowserRenderRequest): DocumentService {
+  const documentService = createDocumentService(request);
+  const resourceBaseUrl = new URL(request.resourceBaseUrl);
+
+  const renderer = {
+    async init(): Promise<void> {},
+    setThemeConfig(config: RendererThemeConfig): void {
+      rendererThemeConfig = config;
+    },
+    getThemeConfig(): RendererThemeConfig | null {
+      return rendererThemeConfig;
+    },
+    render(type: string, content: string | object) {
+      return handleRender({ renderType: type, input: content, themeConfig: rendererThemeConfig });
+    },
+  };
+
+  globalThis.platform = {
+    platform: 'chrome',
+    renderer,
+    resource: {
+      getURL: (resourcePath: string) => new URL(resourcePath, resourceBaseUrl).href,
+      fetch: async (resourcePath: string) => {
+        const response = await fetch(new URL(resourcePath, resourceBaseUrl));
+        if (!response.ok) throw new Error(`Unable to fetch ${resourcePath}: ${response.status}`);
+        return response.text();
+      },
+    },
+    settings: {
+      get: async (key: string) => key === 'firstLineIndent' ? 0 : undefined,
+      set: async () => {},
+    },
+    document: documentService,
+  } as unknown as PlatformAPI;
+
+  return documentService;
+}
+
+async function render(request: CliBrowserRenderRequest): Promise<string> {
+  const markdownContent = document.getElementById('markdown-content');
+  const markdownPage = document.getElementById('markdown-page');
+  if (!(markdownContent instanceof HTMLElement) || !(markdownPage instanceof HTMLElement)) {
+    throw new Error('CLI renderer page is missing its Markdown containers');
+  }
+
+  resetDocument();
+  markdownContent.replaceChildren();
+  rendererThemeConfig = null;
+
+  const documentService = configurePlatform(request);
+  document.documentElement.lang = request.language || 'en';
+  document.title = request.title || request.filename;
+
+  await loadAndApplyTheme(request.theme || 'default');
+
+  markdownContent.classList.remove(
+    'table-layout-left',
+    'table-layout-center',
+    'table-layout-center-full-width',
+  );
+  markdownContent.classList.add(`table-layout-${request.tableLayout || 'center'}`);
+
+  const result = await renderMarkdownDocument({
+    markdown: request.markdown,
+    container: markdownContent,
+    renderer: globalThis.platform!.renderer,
+    translate: (key) => key,
+    frontmatterDisplay: request.frontmatterDisplay || 'hide',
+    tableMergeEmpty: request.tableMergeEmpty ?? false,
+    tableLayout: request.tableLayout || 'center',
+  });
+
+  await result.taskManager.processAll();
+  await document.fonts?.ready;
+
+  const exported = await exportToHtml({
+    container: markdownPage,
+    filename: request.filename,
+    title: request.title || result.title || request.filename,
+    documentService,
+    includeKatexCdn: true,
+  });
+
+  if (!exported.success || !exported.html) {
+    throw new Error(exported.error || 'HTML export failed');
+  }
+  return exported.html;
+}
+
+window.markdownCli = { render };

--- a/src/exporters/html-exporter.ts
+++ b/src/exporters/html-exporter.ts
@@ -69,6 +69,13 @@ function stripPreloadHidingRules(css: string): string {
     .replace(/(^|\n)\s*:root\s*\{[^{}]*color-scheme\s*:\s*light\s+dark[^{}]*\}\s*(\n|$)/gi, '\n');
 }
 
+function escapeHtmlText(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
 const CONTENT_SELECTOR_TOKENS = [
   '#markdown-content',
   '#markdown-page',
@@ -249,7 +256,7 @@ export async function exportToHtml(options: HtmlExportOptions): Promise<HtmlExpo
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>${title}</title>
+  <title>${escapeHtmlText(title)}</title>
   ${katexLink}
   <style>${styles}\n${EXPORT_LAYOUT_CSS}</style>
 </head>

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { parseArgs } from '../scripts/md-to-html.js';
+
+describe('Markdown HTML CLI arguments', () => {
+  it('uses stable defaults', () => {
+    const options = parseArgs(['notes.md']);
+    assert.equal(options.input, 'notes.md');
+    assert.equal(options.theme, 'default');
+    assert.equal(options.frontmatterDisplay, 'hide');
+    assert.equal(options.tableLayout, 'center');
+    assert.equal(options.timeoutMs, 120_000);
+  });
+
+  it('parses rendering options', () => {
+    const options = parseArgs([
+      'notes.md',
+      '--output', 'notes.html',
+      '--theme', 'midnight',
+      '--frontmatter', 'table',
+      '--table-layout', 'left',
+      '--merge-empty-cells',
+      '--timeout', '30',
+    ]);
+
+    assert.equal(options.output, 'notes.html');
+    assert.equal(options.theme, 'midnight');
+    assert.equal(options.frontmatterDisplay, 'table');
+    assert.equal(options.tableLayout, 'left');
+    assert.equal(options.tableMergeEmpty, true);
+    assert.equal(options.timeoutMs, 30_000);
+  });
+
+  it('rejects invalid enum options', () => {
+    assert.throws(
+      () => parseArgs(['notes.md', '--frontmatter', 'show']),
+      /--frontmatter must be hide, table, or raw/,
+    );
+  });
+});

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,7 +1,9 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { parseArgs } from '../scripts/md-to-html.js';
+import path from 'node:path';
+
+import { ensureOutputDirectory, parseArgs } from '../scripts/md-to-html.js';
 
 describe('Markdown HTML CLI arguments', () => {
   it('uses stable defaults', () => {
@@ -37,5 +39,10 @@ describe('Markdown HTML CLI arguments', () => {
       () => parseArgs(['notes.md', '--frontmatter', 'show']),
       /--frontmatter must be hide, table, or raw/,
     );
+  });
+
+  it('accepts an output file directly under an existing filesystem root', async () => {
+    const filesystemRoot = path.parse(process.cwd()).root;
+    await ensureOutputDirectory(path.join(filesystemRoot, 'documd-root-output-test.html'));
   });
 });


### PR DESCRIPTION
```
npm run build:cli
npm run md-to-html -- README.md --output README.html
```

trying to solve #119 
probably worth adding a separate CLI package and publish in npm in the next step.